### PR TITLE
Making paging optional

### DIFF
--- a/lib/jsonapi.ex
+++ b/lib/jsonapi.ex
@@ -155,26 +155,28 @@ defmodule JSONAPI do
   defp handle_paging(doc, mod, params, endpoint) do
     links = %{
       self: mod.url_func().(endpoint, :index, params),
-      next_page: nil,
-      previous_page: nil
     }
 
     number = get_in(params, [:page, :number])
     page_size  = get_in(params, [:page, :size])
     resources = Map.get(doc, :data, [])
 
-    if Enum.count(resources) == page_size do
-      next_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number+1))
-      links = Dict.put(links, :next_page, next_page)
-    else
+    if number && page_size do
+
+      if Enum.count(resources) == page_size do
+        next_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number+1))
+        links = Dict.put(links, :next_page, next_page)
+      else
+      end
+
+      if number > 0 do
+        previous_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number-1))
+        links = Dict.put(links, :previous_page, previous_page)
+      end
+
+      links = Map.get(doc, :links, %{}) |> Map.merge(links)
     end
 
-    if number > 0 do
-      previous_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number-1))
-      links = Dict.put(links, :previous_page, previous_page)
-    end
-
-    links = Map.get(doc, :links, %{}) |> Map.merge(links)
     Map.put(doc, :links, links)
   end
 

--- a/lib/jsonapi.ex
+++ b/lib/jsonapi.ex
@@ -157,20 +157,19 @@ defmodule JSONAPI do
       self: mod.url_func().(endpoint, :index, params),
     }
 
-    number = get_in(params, [:page, :number])
+    page_number = get_in(params, [:page, :number])
     page_size  = get_in(params, [:page, :size])
     resources = Map.get(doc, :data, [])
 
-    if number && page_size do
+    if page_number && page_size do
 
       if Enum.count(resources) == page_size do
-        next_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number+1))
+        next_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], page_number+1))
         links = Dict.put(links, :next_page, next_page)
-      else
       end
 
-      if number > 0 do
-        previous_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number-1))
+      if page_number > 0 do
+        previous_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], page_number-1))
         links = Dict.put(links, :previous_page, previous_page)
       end
 


### PR DESCRIPTION
```
10:05 <pereira_alex> jeregrine: it gives this error:
10:05 <pereira_alex>     ** (ArithmeticError) bad argument in arithmetic expression
10:05 <pereira_alex>         lib/jsonapi.ex:173: JSONAPI.handle_paging/4
10:07 <pereira_alex> jeregrine: seems to be the code: previous_page = mod.url_func().(endpoint, :index, put_in(params, [:page, :number], number-1))
10:09 <pereira_alex> jeregrine: i tried specifying page and number in params, but no luck
New messages
10:11 <jeregrine> pereira_alex: dang. Fix incoming :-)
10:12 <pereira_alex> jeregrine: yeah, i just tryed commenting that piece of code, and it worked right away
```
@mitchellhenke