### PR TITLE
Ensure PlugResponseContentType always returns the conn

### DIFF
--- a/lib/jsonapi/plug.ex
+++ b/lib/jsonapi/plug.ex
@@ -16,8 +16,9 @@ defmodule JSONAPI.PlugResponseContentType do
     register_before_send(conn, fn(conn) ->
       if !conn.assigns[:override_jsonapi] do
         put_resp_content_type(conn, "application/vnd.api+json")
+      else
+        conn
       end
     end)
   end
 end
-


### PR DESCRIPTION
I'd have thought Dialyzer would catch this (because the Plug behvaiour seems to include a spec for the return value of a `register_before_send` callback), but it didn't.

Anyway, pretty important we always get a `conn` back from this. ;)