### PR TITLE
Ecto upgrade

### DIFF
--- a/lib/jsonapi.ex
+++ b/lib/jsonapi.ex
@@ -5,7 +5,7 @@ defmodule JSONAPI do
   out a map to be rendered by Poison.
 
   """
-  import Ecto.Association, only: [loaded?: 1]
+  import Ecto, only: [assoc_loaded?: 1]
 
   @doc """
   Encodes a single map and its associations according to the view module's callbacks.
@@ -87,7 +87,7 @@ defmodule JSONAPI do
       assoc_data = Map.get(data, key)
       rel_data = nil
 
-      rel_data = if loaded?(assoc_data) do
+      rel_data = if assoc_loaded?(assoc_data) do
         as_relationship(assoc_data, view)
       else
         map_key = String.to_atom("#{key}_id")
@@ -105,7 +105,7 @@ defmodule JSONAPI do
         data: rel_data
       })
 
-      if loaded?(assoc_data) && rel_data do
+      if assoc_loaded?(assoc_data) && rel_data do
         data = Map.put(val, :data, assoc_data)
         Map.update!(acc, :include, fn(v) -> v ++ [data] end)
       else

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -1,5 +1,5 @@
 defmodule JSONAPI.Serializer do
-  import Ecto.Association, only: [loaded?: 1]
+  import Ecto, only: [assoc_loaded?: 1]
 
   @doc """
   Takes a view, data and a optional plug connection and returns a fully JSONAPI Serialized document.
@@ -48,7 +48,7 @@ defmodule JSONAPI.Serializer do
     # Handle all the relationships
     Enum.map_reduce(valid_includes, doc, fn({key, rel_view}, acc) ->
       rel_data = Map.get(data, key)   
-      if loaded?(rel_data) && (!is_nil(rel_data) || !Enum.empty(rel_data)) do #Check if we can handle this
+      if assoc_loaded?(rel_data) && (!is_nil(rel_data) || !Enum.empty(rel_data)) do #Check if we can handle this
         only_rel_view = get_view(rel_view)
         # Build the relationship url
         rel_url = view.url_for_rel(data, only_rel_view.type(), conn) 

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule JSONAPI.Mixfile do
   defp deps do
     [
       {:phoenix, "~> 0.13 or ~> 1.0"},
-      {:ecto, "~> 0.11 or ~> 1.0"},
+      {:ecto, "~> 1.0"},
       {:ex_doc, "~> 0.7", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev}
     ]


### PR DESCRIPTION
The only breaking change from 0.11 to 1.0 is that `Ecto.Associations.loaded?` was changed to `Ecto.assoc_loaded?`