### PR TITLE
upgraded phoenix to 1.0. No additional tests broke.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule JSONAPI.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:phoenix, "~> 0.13 or ~> 1.0"},
+      {:phoenix, "~> 1.0"},
       {:ecto, "~> 1.0"},
       {:ex_doc, "~> 0.7", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
Still getting the two `uniq_by/2` test failures on the overhaul branch. Not sure why they are showing up locally. Try checking this branch out and `mix test` before merging.

All in all, the phoenix upgrade did not break anything.