### PR TITLE
Underscore an unused variable in the serializer

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -87,7 +87,7 @@ defmodule JSONAPI.Serializer do
     }
   end
 
-  def encode_rel_data(view, nil), do: nil
+  def encode_rel_data(_view, nil), do: nil
   def encode_rel_data(view, data) when is_list(data) do
     Enum.map(data, fn(d) ->
       encode_rel_data(view, d)


### PR DESCRIPTION
This is to fix the following warning when compiling _jsonapi_ as a dependency

`lib/jsonapi/serializer.ex:90: warning: variable view is unused`