### PR TITLE
Fixed up relationship 'self' links.

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -57,7 +57,7 @@ defmodule JSONAPI.Serializer do
 
       only_rel_view = get_view(rel_view)
       # Build the relationship url
-      rel_url = view.url_for_rel(data, only_rel_view.type(), conn)
+      rel_url = view.url_for_rel(data, key, conn)
       # Build the relationship
       acc = put_in(acc, [:relationships, key], encode_relation(only_rel_view, rel_data, rel_url, conn))
 

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -132,4 +132,19 @@ defmodule JSONAPISerializerTest do
 
     assert Enum.count(encoded[:included]) == 1
   end
+
+  test "serialize handles a relationship self link" do
+    data = %{
+      id: 1,
+      text: "Hello",
+      body: "Hello world",
+      author: %{ id: 2, username: "jason"},
+      comments: []
+    }
+
+    encoded = Serializer.serialize(PostView, data, nil)
+
+    encoded_data = encoded[:data]
+    assert encoded_data[:relationships][:author][:links][:self] == "/mytype/1/relationships/author"
+  end
 end


### PR DESCRIPTION
Uses the key of the relationship instead of the type. Fixes issue #37.

Added a unit test that demonstrates the problem as well.