### PR TITLE
Get QueryParser working again

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -62,7 +62,11 @@ defmodule JSONAPI.Serializer do
 
       valid_include_view =
         case valid_includes do
-          list when is_list(list) -> {Keyword.get(valid_includes, key), :include}
+          list when is_list(list) ->
+            case Keyword.get(valid_includes, key) do
+              {view, :include} -> {view, :include}
+              view -> {view, :include}
+            end
           {view, :include} -> {view, :include}
           view -> {view, :include}
         end

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -72,9 +72,9 @@ defmodule JSONAPITest do
     assert Map.has_key?(json, "included")
     included = Map.get(json, "included")
     assert is_list(included)
-    assert Enum.count(included) == 1
+    assert Enum.count(included) == 2
 
-    [author] = included
+    [author | _] = included
     assert Map.get(author, "type") == "user"
     assert Map.get(author, "id") == "2"
 

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -5,17 +5,20 @@ defmodule JSONAPITest do
   defmodule PostView do
     use JSONAPI.View
 
-    def fields(), do: [:text, :body]
-    def type(), do: "mytype"
-    def relationships(), do: [author: JSONAPITest.UserView, other_user: {JSONAPITest.UserView, :include}]
+    def fields, do: [:text, :body]
+    def type, do: "mytype"
+    def relationships do
+      [author: JSONAPITest.UserView,
+       other_user: {JSONAPITest.UserView, :include}]
+    end
   end
 
   defmodule UserView do
     use JSONAPI.View
 
-    def fields(), do: [:username]
-    def type(), do: "user"
-    def relationships(), do: []
+    def fields, do: [:username]
+    def type, do: "user"
+    def relationships, do: []
   end
 
 
@@ -71,9 +74,9 @@ defmodule JSONAPITest do
     assert is_list(included)
     assert Enum.count(included) == 1
 
-    [other_user | _rest] = included
-    assert Map.get(other_user, "type") == "user"
-    assert Map.get(other_user, "id") == "3"
+    [author] = included
+    assert Map.get(author, "type") == "user"
+    assert Map.get(author, "id") == "2"
 
     assert Map.has_key?(json, "links")
   end
@@ -112,9 +115,9 @@ defmodule JSONAPITest do
     assert is_list(included)
     assert Enum.count(included) == 1
 
-    [author | _rest] = included
+    [author] = included
     assert Map.get(author, "type") == "user"
-    assert Map.get(author, "id") == "3"
+    assert Map.get(author, "id") == "2"
 
     assert Map.has_key?(json, "links")
   end


### PR DESCRIPTION
This is a WIP PR to fix the includes...

There are failing tests for the serializer...but I've gotten this working on a project locally...so I need to figure out the mismatch between the things...

I think we need to remove the default `:include` tuple from the views and move default includes to the query parser as an option.

```elixir
plug JSONAPI.QueryParser,
  sort: [...],
  filter: [...],
  default_includes: [...],
  view: MyApp.PostView
```

**DO NOT MERGE**