### PR TITLE
Use lists of strings for filter and sort options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ If you'd like to use this without phoenix simply use the `JSONAPI.View` and call
 
 ```elixir
 plug JSONAPI.QueryParser
-  sort: [:name, :title],
-  filter: [:q]
+  filter: ~w(name),
+  sort: ~w(name title inserted_at),
   view: PostView
 ```
 

--- a/lib/jsonapi/query_parser.ex
+++ b/lib/jsonapi/query_parser.ex
@@ -71,7 +71,7 @@ defmodule JSONAPI.QueryParser do
   def parse_filter(%Config{opts: opts} = config, filter) do
     opts_filter = Keyword.get(opts, :filter, [])
     Enum.reduce(filter, config, fn({key, val}, acc) ->
-      unless Enum.any?(opts_filter, fn k -> Atom.to_string(k) == key end) do
+      unless Enum.any?(opts_filter, fn k -> k == key end) do
         raise InvalidQuery, resource: config.view.type(), param: key, param_type: :filter
       end
 
@@ -105,29 +105,28 @@ defmodule JSONAPI.QueryParser do
                             param_type: :fields
       end
 
-      old_fields = Map.get(acc, :fields, %{})
-      new_fields = Map.put(old_fields, type, HashSet.to_list(requested_fields))
-      Map.put(acc, :fields, new_fields)
+      %{acc | fields: Map.put(acc.fields, type, HashSet.to_list(requested_fields))}
     end)
   end
 
   def parse_sort(config, ""), do: config
   def parse_sort(%Config{opts: opts} = config, sort_fields) do
-    sorts = String.split(sort_fields, ",")
-    |> Enum.map(fn(field) ->
-      [_, direction, field] = Regex.run(~r/(-?)(\S*)/, field)
-      field = String.to_atom(field)
-      valid_sort = Keyword.get(opts, :sort, [])
+    sorts =
+      sort_fields
+      |> String.split(",")
+      |> Enum.map(fn field ->
+        valid_sort = Keyword.get(opts, :sort, [])
+        [_, direction, field] = Regex.run(~r/(-?)(\S*)/, field)
 
-      unless field in valid_sort do
-        raise InvalidQuery, resource: config.view.type(), param: field, param_type: :sort
-      end
+        unless field in valid_sort do
+          raise InvalidQuery, resource: config.view.type(), param: field, param_type: :sort
+        end
 
-      build_sort(direction, field)
-    end)
-    |> List.flatten()
+        build_sort(direction, String.to_atom(field))
+      end)
+      |> List.flatten()
 
-    Map.put(config, :sort, sorts)
+    %{config | sort: sorts}
   end
 
   def build_sort("", field), do: [asc: field]

--- a/lib/jsonapi/query_parser.ex
+++ b/lib/jsonapi/query_parser.ex
@@ -21,9 +21,9 @@ defmodule JSONAPI.QueryParser do
 
   ```
   plug JSONAPI.QueryParser,
-    view: MyView,
-    sort: [:created_at, :title],
-    filter: [:title]
+    filter: ~w(title),
+    sort: ~w(created_at title),
+    view: MyView
   ```
 
   If your controller's index function recieves a query with params inside those
@@ -33,9 +33,9 @@ defmodule JSONAPI.QueryParser do
   The final output will be a `JSONAPI.Config` struct and will look similar to like
       %JSONAPI.Config{
         view: MyView,
-        opts: [view: MyView, sort: [:created_at, :title], filter: [:title]],
+        opts: [view: MyView, sort: ["created_at", "title"], filter: ["title"]],
         sort: [desc: :created_at] # Easily insertable into an ecto order_by,
-        filter: %{title: "my title"} # Easily reduceable into ecto where clauses
+        filter: [title: "my title"] # Easily reduceable into ecto where clauses
         includes: [comments: :user] # Easily insertable into a Repo.preload,
         fields: %{"myview" => [:id, :text], "comment" => [:id, :body]}
       }

--- a/test/jsonapi_query_parser_test.exs
+++ b/test/jsonapi_query_parser_test.exs
@@ -32,7 +32,7 @@ defmodule JSONAPI.QueryParserTest do
   end
 
   test "parse_sort/2 turns sorts into valid ecto sorts" do
-    config = struct(Config, opts: [sort: [:name, :title]])
+    config = struct(Config, opts: [sort: ~w(name title)], view: MyView)
     assert parse_sort(config, "name,title").sort == [asc: :name, asc: :title]
     assert parse_sort(config, "name").sort == [asc: :name]
     assert parse_sort(config, "-name").sort == [desc: :name]
@@ -47,7 +47,7 @@ defmodule JSONAPI.QueryParserTest do
   end
 
   test "parse_filter/2 turns filters key/val pairs" do
-    config = struct(Config, opts: [filter: [:name]], view: MyView)
+    config = struct(Config, opts: [filter: ~w(name)], view: MyView)
     filter = parse_filter(config, %{"name" => "jason"}).filter
     assert filter[:name] == "jason"
   end
@@ -83,12 +83,12 @@ defmodule JSONAPI.QueryParserTest do
   end
 
   test "parse_fields/2 turns a fields map into a map of validated fields" do
-    config = struct(Config, view: JSONAPI.QueryParserTest.MyView)
+    config = struct(Config, view: MyView)
     assert parse_fields(config, %{"mytype" => "id,text"}).fields == %{"mytype" => [:id, :text]}
   end
 
   test "parse_fields/2 raises on invalid parsing" do
-    config = struct(Config, view: JSONAPI.QueryParserTest.MyView)
+    config = struct(Config, view: MyView)
     assert_raise InvalidQuery, "invalid fields, blag for type mytype", fn ->
       parse_fields(config, %{"mytype" => "blag"})
     end


### PR DESCRIPTION
This change will help us avoid converting user input into atoms for filters and sorts.

I will work on a fix for fields as well.