### PR TITLE
Allow urls to be namespaced

### DIFF
--- a/lib/jsonapi/phoenix.ex
+++ b/lib/jsonapi/phoenix.ex
@@ -1,16 +1,23 @@
 defmodule JSONAPI.PhoenixView do
   @moduledoc """
-  This is an optional Phoenix specific module to include. It will give you default render show and index.json methods.
+  This is an optional Phoenix specific module to include.
+
+  It will give you default render clauses for `show.json` and `index.json`.
   """
 
   defmacro __using__(opts \\ []) do
     quote do
-      def render("show.json", %{data: data, conn: conn}), do: show(data, conn, conn.params)
-      def render("show.json", %{data: data, conn: conn, params: params}), do: show(data, conn, params)
       use JSONAPI.View, unquote(opts)
 
-      def render("index.json", %{data: data, conn: conn}), do: index(data, conn, conn.params)
-      def render("index.json", %{data: data, conn: conn, params: params}), do: show(data, conn, params)
+      def render("show.json", %{data: data, conn: conn}),
+        do: show(data, conn, conn.params)
+      def render("show.json", %{data: data, conn: conn, params: params}),
+        do: show(data, conn, params)
+
+      def render("index.json", %{data: data, conn: conn}),
+        do: index(data, conn, conn.params)
+      def render("index.json", %{data: data, conn: conn, params: params}),
+        do: show(data, conn, params)
     end
   end
 end

--- a/lib/jsonapi/phoenix.ex
+++ b/lib/jsonapi/phoenix.ex
@@ -3,11 +3,11 @@ defmodule JSONAPI.PhoenixView do
   This is an optional Phoenix specific module to include. It will give you default render show and index.json methods.
   """
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts \\ []) do
     quote do
-      use JSONAPI.View
       def render("show.json", %{data: data, conn: conn}), do: show(data, conn, conn.params)
       def render("show.json", %{data: data, conn: conn, params: params}), do: show(data, conn, params)
+      use JSONAPI.View, unquote(opts)
 
       def render("index.json", %{data: data, conn: conn}), do: index(data, conn, conn.params)
       def render("index.json", %{data: data, conn: conn, params: params}), do: show(data, conn, params)

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -1,0 +1,21 @@
+defmodule JSONAPI.ViewTest do
+  use ExUnit.Case, async: true
+
+  defmodule PostView do
+    use JSONAPI.View, type: "posts", namespace: "/api"
+  end
+
+  test "type/0 when specified via using macro" do
+    assert PostView.type == "posts"
+  end
+
+  test "url_for/2 with namespace" do
+    assert PostView.url_for(nil, nil) == "/api/posts"
+    assert PostView.url_for([], nil) == "/api/posts"
+    assert PostView.url_for(%{id: 1}, nil) == "/api/posts/1"
+    assert PostView.url_for([], %Plug.Conn{}) == "http://www.example.com/api/posts"
+    assert PostView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.example.com/api/posts/1"
+    assert PostView.url_for_rel([], "comments", %Plug.Conn{}) == "http://www.example.com/api/posts/relationships/comments"
+    assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) == "http://www.example.com/api/posts/1/relationships/comments"
+  end
+end


### PR DESCRIPTION
This PR fixes #35.

It also allows you to specify the `type` function via passing an option:

```elixir
defmodule PostView do
  use JSONAPI.View, type: "posts", namespace: "/api"
  ...
end
```