### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you'd like to use this without phoenix simply use the `JSONAPI.View` and call
 ## Parsing and validating a JSONAPI Request
 
 ```elixir
-plug JSONAPI.QueryParser
+plug JSONAPI.QueryParser,
   filter: ~w(name),
   sort: ~w(name title inserted_at),
   view: PostView


### PR DESCRIPTION
Fixed missing comma in code snippet to add the QueryParser. It was causing a syntax error.