### PR TITLE
Correct README for calling serialization without phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ end
 ```
 is an example of a basic view. You can now call `render(conn, "show.json", MyApp.PostView, %{data: my_data})` or `'list.json` normally.
 
-If you'd like to use this without phoenix simply use the `JSONAPI.View` and call `JSONAPI.Serialize(MyApp.PostView, data, conn)`.
+If you'd like to use this without phoenix simply use the `JSONAPI.View` and call `JSONAPI.Serializer.serialize(MyApp.PostView, data, conn)`.
 
 ## Parsing and validating a JSONAPI Request
 


### PR DESCRIPTION
First just wanted to say thanks for this awesome library!

I noticed an issue with the README while working through some different usages. The call to `serialize` was incorrect in the README when you are not using phoenix. 

Just a quick little README correction.
