### PR TITLE
Add Host Configuration option

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -106,17 +106,16 @@ defmodule JSONAPI.View do
       end
 
       def url_for(data, %Plug.Conn{}=conn) when is_list(data) do
-        "#{Atom.to_string(conn.scheme)}://#{conn.host}#{@namespace}/#{type()}"
+        "#{scheme(conn)}://#{host(conn)}#{@namespace}/#{type()}"
       end
 
       def url_for(data, %Plug.Conn{}=conn) do
-        "#{Atom.to_string(conn.scheme)}://#{conn.host}#{@namespace}/#{type()}/#{id(data)}"
+        "#{scheme(conn)}://#{host(conn)}#{@namespace}/#{type()}/#{id(data)}"
       end
 
       def url_for_rel(data, rel_type, conn) do
         "#{url_for(data, conn)}/relationships/#{rel_type}"
       end
-
 
       if Code.ensure_loaded?(Phoenix) do
         def render("show.json", %{data: data, conn: conn}),
@@ -129,6 +128,10 @@ defmodule JSONAPI.View do
         def render("index.json", %{data: data, conn: conn, params: params}),
           do: show(data, conn, params)
       end
+
+      defp host(conn), do: Application.get_env(:jsonapi, :host, conn.host)
+
+      defp scheme(conn), do: Application.get_env(:jsonapi, :scheme, to_string(conn.scheme))
 
       defoverridable attributes: 2,
                      fields: 0,

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -23,7 +23,7 @@ defmodule JSONAPI.ViewTest do
     assert PostView.type == "posts"
   end
 
-  test "url_for/2 with namespace" do
+  test "url_for/2" do
     assert PostView.url_for(nil, nil) == "/api/posts"
     assert PostView.url_for([], nil) == "/api/posts"
     assert PostView.url_for(%{id: 1}, nil) == "/api/posts/1"
@@ -31,6 +31,18 @@ defmodule JSONAPI.ViewTest do
     assert PostView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.example.com/api/posts/1"
     assert PostView.url_for_rel([], "comments", %Plug.Conn{}) == "http://www.example.com/api/posts/relationships/comments"
     assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) == "http://www.example.com/api/posts/1/relationships/comments"
+
+    Application.put_env(:jsonapi, :host, "www.otherhost.com")
+    assert PostView.url_for([], %Plug.Conn{}) == "http://www.otherhost.com/api/posts"
+    assert PostView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.otherhost.com/api/posts/1"
+    assert PostView.url_for_rel([], "comments", %Plug.Conn{}) == "http://www.otherhost.com/api/posts/relationships/comments"
+    assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) == "http://www.otherhost.com/api/posts/1/relationships/comments"
+
+    Application.put_env(:jsonapi, :scheme, "ftp")
+    assert PostView.url_for([], %Plug.Conn{}) == "ftp://www.otherhost.com/api/posts"
+    assert PostView.url_for(%{id: 1}, %Plug.Conn{}) == "ftp://www.otherhost.com/api/posts/1"
+    assert PostView.url_for_rel([], "comments", %Plug.Conn{}) == "ftp://www.otherhost.com/api/posts/relationships/comments"
+    assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) == "ftp://www.otherhost.com/api/posts/1/relationships/comments"
   end
 
   @tag :compile_phoenix


### PR DESCRIPTION
This PR adds the ability to add a host configuration that takes president over `conn.host`
Also adds the ability to add a scheme configuration that takes president over `conn.scheme`

Tested within our application and it works.
ex: `links: %{self: "http://www.not_example.com/api/user/535937“}`