### PR TITLE
Document configuration options in README and view module

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ when Ecto gets more complex field selection support we will go further to only q
 
 You will need to handle filtering yourself, the filter is just a map with key=value.
 
+## Configuration
+By default host and scheme are pulled from the provided conn but can be overridden via configuration like so:
+
+```elixir
+config :jsonapi,
+  host: "www.someotherhost.com",
+  scheme: "https",
+  underscore_to_dash: true
+```
+
+Additionally, JSONAPI now recommends the use of dashes (`-`) in place of underscore (`_`) as a word separator. Enabling this change is easy with the `underscore_to_dash` option, which handles the conversion for you.
+
 ## Other
 
 - Feel free to make PR's. I will do my best to respond within a day or two.

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -59,6 +59,16 @@ defmodule JSONAPI.View do
   If you always want to include a relationship. First make sure its always preloaded
   and then use the `[user: {UserView, :include}]` syntax in your `includes` function. This tells
   the serializer to *always* include if its loaded.
+
+  ## Options
+    * `:host` (binary) - Allows the `host` to be overrided for generated URLs.  Defaults to `host` of the supplied `conn`.
+    
+    * `:scheme` (atom) - Enables configuration of the HTTP scheme for generated URLS.  Defaults to `scheme` from the provided `conn`.
+
+    * `:underscore_to_dash` (boolean) - Use dash (`-`) as the word separated for JSON in place of underscore (`_`) per the JSONAPI spec [recommendations](http://jsonapi.org/recommendations/).  Defaults to `false`.
+
+  The default behaviour for `host` and `scheme` is to derive it from the `conn` provided, while the
+  default style for presentation in names is to be underscored and not dashed.
   """
   defmacro __using__(opts \\ []) do
     {type, opts} = Keyword.pop(opts, :type)


### PR DESCRIPTION
Hey @jeregrine!

Just thought since there were the new configuration options added in 0.5.0 that I would throw a configuration section into the README so it was more clear and also make a mention in the doc for the view module.

These arent exactly huge, but I thought it might make things a little less bumpy for people who might not have dove into the code to realize where there are configurations being thrown in.