### PR TITLE
Put correct render call in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ defmodule MyApp.PostView do
   end
 end
 ```
-is an example of a basic view. You can now call `render(conn, "show.json", MyApp.PostView, %{data: my_data})` or `'list.json` normally.
+is an example of a basic view. You can now call `render(conn, MyApp.PostView, "show.json", %{data: my_data})` or `'list.json` normally.
 
 If you'd like to use this without phoenix simply use the `JSONAPI.View` and call `JSONAPI.Serializer.serialize(MyApp.PostView, data, conn)`.
 


### PR DESCRIPTION
Phoenix `render/4` requires the order of `conn`, `ViewModule`, `action`, `data` and the current readme has the view module and action swapped.