### PR TITLE
Dashes in relationships key

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -4,6 +4,7 @@ defmodule JSONAPI.Serializer do
   """
 
   import JSONAPI.Ecto, only: [assoc_loaded?: 1]
+  alias JSONAPI.Utils.Underscore
 
   @doc """
   Takes a view, data and a optional plug connection and returns a fully JSONAPI Serialized document.
@@ -41,7 +42,7 @@ defmodule JSONAPI.Serializer do
     doc = %{
       id: view.id(data),
       type: view.type(),
-      attributes: view.attributes(data, conn),
+      attributes: underscore(view.attributes(data, conn)),
       relationships: %{},
       links: %{
         self: view.url_for(data, conn)
@@ -75,7 +76,7 @@ defmodule JSONAPI.Serializer do
     # Build the relationship url
     rel_url = view.url_for_rel(data, key, conn)
     # Build the relationship
-    acc = put_in(acc, [:relationships, key], encode_relation(only_rel_view, rel_data, rel_url, conn))
+    acc = put_in(acc, [:relationships, underscore(key)], encode_relation(only_rel_view, rel_data, rel_url, conn))
 
     valid_include_view = include_view(valid_includes, key)
 
@@ -163,4 +164,12 @@ defmodule JSONAPI.Serializer do
 
   def get_view({view, :include}), do: view
   def get_view(view), do: view
+
+  def underscore(data) do
+    if Underscore.underscore?() do
+      Underscore.underscore(data)
+    else
+      data
+    end
+  end
 end

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -1,0 +1,31 @@
+defmodule JSONAPI.Utils.Underscore do
+  @moduledoc """
+  Helpers for replacing underscores with dashes.
+  """
+
+  def underscore?, do: Application.get_env(:jsonapi, :underscore_to_dash, false)
+
+  def underscore(value) when is_atom(value) do
+    value
+    |> to_string
+    |> underscore
+  end
+
+  def underscore(value) when is_binary(value) do
+    String.replace(value, "_", "-")
+  end
+
+  def underscore(value) when is_map(value) do
+    value
+    |> Enum.map(&underscore/1)
+    |> Enum.into(%{})
+  end
+
+  def underscore({key, value}) do
+    if is_map(value) do
+      {underscore(key), underscore(value)}
+    else
+      {underscore(key), value}
+    end
+  end
+end

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -90,15 +90,8 @@ defmodule JSONAPI.View do
         def type, do: raise "Need to implement type/0"
       end
 
-      #TODO Figure out the nesting of fields
       def attributes(data, conn) do
-        data = visible_fields(data)
-
-        if underscore?() do
-          underscore(data)
-        else
-          data
-        end
+        visible_fields(data)
       end
 
       def meta(_data, _conn), do: nil
@@ -151,21 +144,6 @@ defmodule JSONAPI.View do
       end
 
       defp visible_fields(data), do: Map.take(data, fields() -- hidden())
-
-      defp underscore?, do: Application.get_env(:jsonapi, :underscore_to_dash, false)
-
-      defp underscore(data) do
-        data
-        |> Enum.map(fn {key, value} -> {underscore_key(key), value} end)
-        |> Enum.into(%{})
-      end
-
-      defp underscore_key(key) do
-        key
-        |> to_string
-        |> String.replace("_", "-")
-        |> String.to_atom
-      end
 
       defp host(conn), do: Application.get_env(:jsonapi, :host, conn.host)
 

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -72,11 +72,4 @@ defmodule JSONAPI.ViewTest do
     expected_map = %{age: 100, first_name: "Jason", last_name: "S"}
     assert expected_map == UserView.attributes(%{age: 100, first_name: "Jason", last_name: "S", password: "securepw"}, nil)
   end
-
-  test "attributes/2 with `:underscore_to_dash` option" do
-    Application.put_env(:jsonapi, :underscore_to_dash, true)
-    expected_map = %{age: 100, "first-name": "Jason", "last-name": "S"}
-    assert expected_map == UserView.attributes(%{age: 100, first_name: "Jason", last_name: "S"}, nil)
-    Application.put_env(:jsonapi, :underscore_to_dash, false)
-  end
 end


### PR DESCRIPTION
Not small refactor of `underscore_to_dash` to make relationship keys also have that functionality.

if `underscore_to_dash` is set, relationship keys will also now have their underscores replaced by dashes.

```elixir
%{
  data: %{
    attributes: %{
      full_description: "description"
    }
  },
  relationships: %{
    best_comments: []
  }
}
```

We'll get:

```elixir
%{
  data: %{
    attributes: %{
      "full-description": "description"
    }
  },
  relationships: %{
    "best-comments": []
  }
}
```