### PR TITLE
Avoid calling Enum.map on maps that happen to be structs

### DIFF
--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -15,6 +15,10 @@ defmodule JSONAPI.Utils.Underscore do
     String.replace(value, "_", "-")
   end
 
+  def underscore(%{__struct__: _} = value) when is_map(value) do
+    value
+  end
+
   def underscore(value) when is_map(value) do
     value
     |> Enum.map(&underscore/1)

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -5,7 +5,7 @@ defmodule JSONAPISerializerTest do
   defmodule PostView do
     use JSONAPI.View
 
-    def fields, do: [:text, :body, :full_description]
+    def fields, do: [:text, :body, :full_description, :inserted_at]
     def meta(data, _conn), do: %{meta_text: "meta_#{data[:text]}"}
     def type, do: "mytype"
     def relationships do
@@ -207,6 +207,7 @@ defmodule JSONAPISerializerTest do
     data = %{
       id: 1,
       text: "Hello",
+      inserted_at: NaiveDateTime.utc_now,
       body: "Hello world",
       full_description: "This_is_my_description",
       author: %{ id: 2, username: "jbonds", first_name: "jerry", last_name: "bonds"},
@@ -224,6 +225,7 @@ defmodule JSONAPISerializerTest do
     included = encoded[:included]
 
     assert attributes["full-description"] == data[:full_description]
+    assert attributes["inserted-at"] == data[:inserted_at]
     assert Enum.find(included, fn(i) -> i[:type] == "user" && i[:id] == "2" end)[:attributes]["last-name"] == "bonds"
     assert Enum.find(included, fn(i) -> i[:type] == "user" && i[:id] == "4" end)[:attributes]["last-name"] == "bronds"
     assert List.first(relationships["best-comments"][:data])[:id] == "5"


### PR DESCRIPTION
In cases where a struct is passed to `underscore`, it currently tries to call `Enum.map` on it, which causes something like this:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for ~N[2017-11-15 16:56:31.268901]
```