### PR TITLE
Remove top level links if configured

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -25,7 +25,7 @@ defmodule JSONAPI.Serializer do
       data: encoded_data,
       included: flatten_included(to_include)
     }
-    merge_links(encoded_data, data, view, conn, remove_links?)
+    merge_links(encoded_data, data, view, conn, remove_links?())
   end
 
   def encode_data(view, data, conn, query_includes) when is_list(data) do
@@ -45,7 +45,7 @@ defmodule JSONAPI.Serializer do
       relationships: %{}
     }
 
-    doc = merge_links(encoded_data, data, view, conn, remove_links?)
+    doc = merge_links(encoded_data, data, view, conn, remove_links?())
 
     doc =
       case view.meta(data, conn) do
@@ -107,10 +107,10 @@ defmodule JSONAPI.Serializer do
   end
 
   def encode_relation({rel_view, rel_data, _rel_url, _conn} = info) do
-    %{
+    data = %{
       data: encode_rel_data(rel_view, rel_data)
     }
-    |> merge_related_links(info, remove_links?)
+    merge_related_links(data, info, remove_links?())
   end
 
   defp merge_links(doc, data, view, conn, false) do

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -25,7 +25,7 @@ defmodule JSONAPI.Serializer do
       data: encoded_data,
       included: flatten_included(to_include)
     }
-    merge_links(encoded_data, data, view, conn, Application.get_env(:jsonapi, :remove_links, false))
+    merge_links(encoded_data, data, view, conn, remove_links?)
   end
 
   def encode_data(view, data, conn, query_includes) when is_list(data) do
@@ -45,7 +45,7 @@ defmodule JSONAPI.Serializer do
       relationships: %{}
     }
 
-    doc = merge_links(encoded_data, data, view, conn, Application.get_env(:jsonapi, :remove_links, false))
+    doc = merge_links(encoded_data, data, view, conn, remove_links?)
 
     doc =
       case view.meta(data, conn) do
@@ -110,7 +110,7 @@ defmodule JSONAPI.Serializer do
     %{
       data: encode_rel_data(rel_view, rel_data)
     }
-    |> merge_related_links(info, Application.get_env(:jsonapi, :remove_links, false))
+    |> merge_related_links(info, remove_links?)
   end
 
   defp merge_links(doc, data, view, conn, false) do
@@ -177,4 +177,6 @@ defmodule JSONAPI.Serializer do
       data
     end
   end
+
+  defp remove_links?, do: Application.get_env(:jsonapi, :remove_links, false)
 end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -21,13 +21,11 @@ defmodule JSONAPI.Serializer do
 
     {to_include, encoded_data} = encode_data(view, data, conn, query_includes)
 
-    %{
-      links: %{
-        self: view.url_for(data, conn)
-      },
+    encoded_data = %{
       data: encoded_data,
       included: flatten_included(to_include)
     }
+    merge_links(encoded_data, data, view, conn, Application.get_env(:jsonapi, :remove_links, false))
   end
 
   def encode_data(view, data, conn, query_includes) when is_list(data) do

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -66,9 +66,11 @@ defmodule JSONAPISerializerTest do
     }
 
     encoded = Serializer.serialize(PostView, data, nil)
+    assert encoded[:links][:self] == PostView.url_for(data, nil)
     encoded_data = encoded[:data]
     assert encoded_data[:id] == PostView.id(data)
     assert encoded_data[:type] == PostView.type()
+    assert encoded_data[:links][:self] == PostView.url_for(data, nil)
 
     assert %{meta_text: "meta_Hello"} = encoded_data[:meta]
 

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -273,6 +273,7 @@ defmodule JSONAPISerializerTest do
 
     refute relationships[:links]
     refute encoded[:data][:links]
+    refute encoded[:links]
 
     Application.delete_env(:jsonapi, :remove_links)
   end


### PR DESCRIPTION
Looks like links can be both top level and resource.  This removes the top level as well if configured.