### PR TITLE
updates plug to allow data with only relationships

### DIFF
--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -8,6 +8,7 @@ defmodule JSONAPI.FormatRequired do
   def init(opts), do: opts
 
   def call(%{method: method} = conn, _opts) when method in ["DELETE", "GET", "HEAD"], do: conn
+  def call(%{params: %{"data" => %{"relationships" => _}}} = conn, _), do: conn
   def call(%{params: %{"data" => %{"attributes" => _}}} = conn, _), do: conn
   def call(%{params: %{"data" => _}} = conn, _), do: send_error(conn, missing_data_attributes_param())
   def call(conn, _), do: send_error(conn, missing_data_param())

--- a/test/jsonapi/plugs/format_required_test.exs
+++ b/test/jsonapi/plugs/format_required_test.exs
@@ -32,6 +32,15 @@ defmodule JSONAPI.FormatRequiredTest do
     assert %{"source" => %{"pointer" => "/data/attributes"}, "title" => "Missing attributes in data parameter"} = error
   end
 
+  test "does not halt if only relationships member is present" do
+    conn =
+      :post
+      |> conn("/example", Poison.encode!(%{data: %{relationships: %{}}}))
+      |> call_plug
+
+    refute conn.halted
+  end
+
   test "passes request through" do
     conn =
       :post


### PR DESCRIPTION
Fixes an issue with the `FormatRequired` plug where an error was returned for a valid resource object.

Specifically, a "data" object with only a "relationships" member was not allowed before this change.

see: http://jsonapi.org/format/#document-resource-objects

I found this while trying to patch only relationships (no attribute changes) for a resource like this: http://jsonapi.org/format/#crud-updating-resource-relationships