### PR TITLE
include meta as top level document member

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A project that will render your data models into [JSONAPI Documents](http://json
 - [X] Handling of sparse fieldsets
 - [X] Handling of includes
 - [X] Handling of pagination
+- [X] Handling of meta
 
 ## How to use with Phoenix
 
@@ -33,6 +34,12 @@ defmodule MyApp.PostView do
     String.slice(post.body, 0..5)
   end
 
+  def meta(data, _conn) do
+    # this will add meta to each record
+    # To add meta as a top level property, pass as argument to render function (shown below)
+    %{meta_text: "meta_#{data[:text]}"}
+  end
+
   def relationships do
     # The post's author will be included by default
     [author: {MyApp.UserView, :include},
@@ -40,9 +47,9 @@ defmodule MyApp.PostView do
   end
 end
 ```
-is an example of a basic view. You can now call `render(conn, MyApp.PostView, "show.json", %{data: my_data})` or `'index.json` normally.
+is an example of a basic view. You can now call `render(conn, MyApp.PostView, "show.json", %{data: my_data, meta: meta})` or `'index.json` normally.
 
-If you'd like to use this without phoenix simply use the `JSONAPI.View` and call `JSONAPI.Serializer.serialize(MyApp.PostView, data, conn)`.
+If you'd like to use this without phoenix simply use the `JSONAPI.View` and call `JSONAPI.Serializer.serialize(MyApp.PostView, data, conn, meta)`.
 
 ## Parsing and validating a JSONAPI Request
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A project that will render your data models into [JSONAPI Documents](http://json
 - [X] Handling of sparse fieldsets
 - [X] Handling of includes
 - [X] Handling of pagination
-- [X] Handling of meta
+- [X] Handling of top level meta data
 
 ## How to use with Phoenix
 

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -13,7 +13,7 @@ defmodule JSONAPI.Serializer do
   Please refer to `JSONAPI.View` for more information. If you are in interested in relationships
   and includes you may also want to reference the `JSONAPI.QueryParser`.
   """
-  def serialize(view, data, conn \\ nil) do
+  def serialize(view, data, conn \\ nil, meta \\ nil) do
     query_includes =
       case conn do
         %Plug.Conn{assigns: %{jsonapi_query: %{includes: includes}}} -> includes
@@ -24,7 +24,8 @@ defmodule JSONAPI.Serializer do
 
     encoded_data = %{
       data: encoded_data,
-      included: flatten_included(to_include)
+      included: flatten_included(to_include),
+      meta: meta
     }
 
     merge_links(encoded_data, data, view, conn, remove_links?())

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -72,7 +72,7 @@ defmodule JSONAPITest do
     defp passthrough(conn, _) do
       resp =
         PostView
-        |> JSONAPI.Serializer.serialize(conn.assigns[:data], conn)
+        |> JSONAPI.Serializer.serialize(conn.assigns[:data], conn, conn.assigns[:meta])
         |> Poison.encode!()
 
       Plug.Conn.send_resp(conn, 200, resp)
@@ -92,12 +92,15 @@ defmodule JSONAPITest do
           other_user: %{username: "josh", id: 3}
         }
       ])
+      |> Plug.Conn.assign(:meta, %{total_pages: 1})
       |> MyPostPlug.call([])
 
     json = conn.resp_body |> Poison.decode!()
 
     assert Map.has_key?(json, "data")
     data_list = Map.get(json, "data")
+    meta = Map.get(json, "meta")
+    assert meta["total_pages"] == 1
 
     assert Enum.count(data_list) == 1
     [data | _] = data_list

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -80,6 +80,15 @@ defmodule JSONAPISerializerTest do
     end
   end
 
+  test "serialize includes meta as top level member" do
+    meta = %{total_pages: 10}
+    encoded = Serializer.serialize(PostView, %{id: 1, text: "Hello"}, nil, meta)
+    assert %{total_pages: 10} = encoded[:meta]
+
+    encoded = Serializer.serialize(CommentView, %{id: 1}, nil, nil)
+    assert encoded[:meta] == nil
+  end
+
   test "serialize only includes meta if provided" do
     encoded = Serializer.serialize(PostView, %{id: 1, text: "Hello"}, nil)
     assert %{meta_text: "meta_Hello"} = encoded[:data][:meta]


### PR DESCRIPTION
This PR adds the ability to pass a `meta` map to the render function.

The current functionality relies on the meta data to be present on the `data` attribute.  However, for example, on index routes, `data` is simply a List and some attributes to filter/paginate the list may need to be passed through to the response that aren't implicitly included/apart of the `data`.

Lmk your thoughts!

Ref #96 