### PR TITLE
Do not build relationships section for not loaded relationships

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -61,7 +61,7 @@ defmodule JSONAPI.Serializer do
 
   def encode_relationships(conn, doc, {view, data, _, _} = view_info) do
     view.relationships()
-    |> Enum.filter(&(is_data_loaded?(Map.get(data, elem(&1, 0)))))
+    |> Enum.filter(&is_data_loaded?(Map.get(data, elem(&1, 0))))
     |> Enum.map_reduce(doc, &build_relationships(conn, view_info, &1, &2))
   end
 

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -59,9 +59,10 @@ defmodule JSONAPI.Serializer do
     encode_relationships(conn, doc, {view, data, query_includes, valid_includes})
   end
 
-  def encode_relationships(conn, doc, {view, _, _, _} = view_info) do
-    rels = view.relationships()
-    Enum.map_reduce(rels, doc, &build_relationships(conn, view_info, &1, &2))
+  def encode_relationships(conn, doc, {view, data, _, _} = view_info) do
+    view.relationships()
+    |> Enum.filter(&(is_data_loaded?(Map.get(data, elem(&1, 0)))))
+    |> Enum.map_reduce(doc, &build_relationships(conn, view_info, &1, &2))
   end
 
   def build_relationships(

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -181,7 +181,7 @@ defmodule JSONAPISerializerTest do
     assert attributes[:body] == data[:body]
 
     assert encoded_data[:links][:self] == PostView.url_for(data, nil)
-    assert map_size(encoded_data[:relationships]) == 2
+    assert map_size(encoded_data[:relationships]) == 1
 
     assert Enum.count(encoded[:included]) == 1
   end
@@ -206,7 +206,7 @@ defmodule JSONAPISerializerTest do
     assert attributes[:body] == data[:body]
 
     assert encoded_data[:links][:self] == PostView.url_for(data, nil)
-    assert map_size(encoded_data[:relationships]) == 2
+    assert map_size(encoded_data[:relationships]) == 1
 
     assert Enum.count(encoded[:included]) == 1
   end


### PR DESCRIPTION
Currently if a resource has defined relationships on its view it is always generated an record in the `relationships` section. If the relationship is not loaded, it generates a relationship record with `"id": null` and record type. 

This is not precisely per spec and can cause weird issues with front-end libraries when a record appears in relationships section with an id value of null.

Also, in case of one-to-many relationships, having a single record with id null can be misleading.

This PR updates the logic to not include an empty record if the relationship is not loaded.