### PR TITLE
Dasherize keys in relationship urls

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -81,12 +81,13 @@ defmodule JSONAPI.Serializer do
 
     only_rel_view = get_view(rel_view)
     # Build the relationship url
-    rel_url = view.url_for_rel(data, key, conn)
+    rel_key = underscore(key)
+    rel_url = view.url_for_rel(data, rel_key, conn)
     # Build the relationship
     acc =
       put_in(
         acc,
-        [:relationships, underscore(key)],
+        [:relationships, rel_key],
         encode_relation({only_rel_view, rel_data, rel_url, conn})
       )
 

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -386,6 +386,9 @@ defmodule JSONAPISerializerTest do
 
     assert List.first(relationships["best-comments"][:data])[:id] == "5"
 
+    assert relationships["best-comments"][:links][:self] ==
+             "/mytype/1/relationships/best-comments"
+
     Application.delete_env(:jsonapi, :underscore_to_dash)
   end
 


### PR DESCRIPTION
Hi, thanks for this library, it's really nice to use!

I noticed that the keys that become part of relationship urls weren't getting dashed. So this is a small test and fix. Should be compatible with #102.

Cheers!