### PR TITLE
Allows the view to add links

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -5,6 +5,7 @@ defmodule JSONAPI.Serializer do
 
   import JSONAPI.Ecto, only: [assoc_loaded?: 1]
   alias JSONAPI.Utils.Underscore
+  require Logger
 
   @doc """
   Takes a view, data and a optional plug connection and returns a fully JSONAPI Serialized document.
@@ -139,7 +140,7 @@ defmodule JSONAPI.Serializer do
     pagination_links = view.links(data, conn)
 
     if Enum.empty?(pagination_links) do
-      IO.warn(
+      Logger.info(
         "You've set with_pagination but have not defined any pagination links, thus no pagination links will be returned"
       )
     end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -28,7 +28,7 @@ defmodule JSONAPI.Serializer do
       meta: meta
     }
 
-    merge_links(encoded_data, data, view, conn, remove_links?())
+    merge_links(encoded_data, data, view, conn, remove_links?(), true)
   end
 
   def encode_data(view, data, conn, query_includes) when is_list(data) do
@@ -48,7 +48,7 @@ defmodule JSONAPI.Serializer do
       relationships: %{}
     }
 
-    doc = merge_links(encoded_data, data, view, conn, remove_links?())
+    doc = merge_links(encoded_data, data, view, conn, remove_links?(), false)
 
     doc =
       case view.meta(data, conn) do
@@ -135,11 +135,19 @@ defmodule JSONAPI.Serializer do
     merge_related_links(data, info, remove_links?())
   end
 
-  defp merge_links(doc, data, view, conn, false) do
+  defp merge_links(doc, data, view, conn, false, true) do
+    links =
+      %{self: view.url_for(data, conn)}
+      |> Map.merge(view.links(data, conn))
+
+    Map.merge(doc, %{links: links})
+  end
+
+  defp merge_links(doc, data, view, conn, false, false) do
     Map.merge(doc, %{links: %{self: view.url_for(data, conn)}})
   end
 
-  defp merge_links(doc, _data, _view, _conn, _remove_links), do: doc
+  defp merge_links(doc, _data, _view, _conn, _remove_links, _with_pagination), do: doc
 
   defp merge_related_links(
          encoded_data,

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -28,7 +28,7 @@ defmodule JSONAPI.Serializer do
       meta: meta
     }
 
-    merge_links(encoded_data, data, view, conn, remove_links?(), true)
+    merge_links(encoded_data, data, view, conn, remove_links?(), with_pagination?())
   end
 
   def encode_data(view, data, conn, query_includes) when is_list(data) do
@@ -136,6 +136,14 @@ defmodule JSONAPI.Serializer do
   end
 
   defp merge_links(doc, data, view, conn, false, true) do
+    pagination_links = view.links(data, conn)
+
+    if Enum.empty?(pagination_links) do
+      IO.warn(
+        "You've set with_pagination but have not defined any pagination links, thus no pagination links will be returned"
+      )
+    end
+
     links =
       %{self: view.url_for(data, conn)}
       |> Map.merge(view.links(data, conn))
@@ -217,4 +225,5 @@ defmodule JSONAPI.Serializer do
   end
 
   defp remove_links?, do: Application.get_env(:jsonapi, :remove_links, false)
+  defp with_pagination?, do: Application.get_env(:jsonapi, :with_pagination, false)
 end

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -120,6 +120,8 @@ defmodule JSONAPI.View do
         end)
       end
 
+      def links(_data, _conn), do: %{}
+
       def meta(_data, _conn), do: nil
 
       def relationships, do: []
@@ -155,6 +157,21 @@ defmodule JSONAPI.View do
         "#{url_for(data, conn)}/relationships/#{rel_type}"
       end
 
+      def url_for_pagination(data, conn, pagination_attrs) do
+        pagination_attrs
+        |> Enum.reduce(%{}, fn {key, value}, acc ->
+          Map.put(acc, "page[#{key}]", value)
+        end)
+        |> URI.encode_query()
+        |> prepare_url(data, conn)
+      end
+
+      defp prepare_url("", data, conn), do: url_for(data, conn)
+
+      defp prepare_url(query, data, conn) do
+        "#{url_for(data, conn)}?#{query}"
+      end
+
       if Code.ensure_loaded?(Phoenix) do
         def render("show.json", %{data: data, conn: conn, params: params, meta: meta}),
           do: show(data, conn, params, meta: meta)
@@ -178,6 +195,7 @@ defmodule JSONAPI.View do
       defp scheme(conn), do: Application.get_env(:jsonapi, :scheme, to_string(conn.scheme))
 
       defoverridable attributes: 2,
+                     links: 2,
                      fields: 0,
                      hidden: 0,
                      id: 1,

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -75,6 +75,13 @@ defmodule JSONAPI.ViewTest do
              "ftp://www.otherhost.com/api/posts/1/relationships/comments"
   end
 
+  test "url_for_pagination/3" do
+    assert PostView.url_for_pagination(nil, nil, %{}) == "/api/posts"
+
+    assert PostView.url_for_pagination(nil, nil, %{number: 1, size: 10}) ==
+             "/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+  end
+
   @tag :compile_phoenix
   test "render/2 is defined when 'Phoenix' is loaded" do
     assert {:render, 2} in CommentView.__info__(:functions)

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -2,7 +2,7 @@ defmodule JSONAPISerializerTest do
   use ExUnit.Case, async: false
   alias JSONAPI.Serializer
 
-  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
 
   defmodule PostView do
     use JSONAPI.View
@@ -458,13 +458,13 @@ defmodule JSONAPISerializerTest do
     Application.put_env(:jsonapi, :with_pagination, true)
 
     output =
-      capture_io(:stderr, fn ->
+      capture_log(fn ->
         encoded = Serializer.serialize(UserView, data, nil)
 
         refute encoded[:links][:next]
       end)
 
-    assert Regex.match?(~r/warning:.*with_pagination/, output)
+    assert Regex.match?(~r/info.*with_pagination/, output)
     Application.delete_env(:jsonapi, :with_pagination)
   end
 

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -117,9 +117,7 @@ defmodule JSONAPISerializerTest do
 
     encoded = Serializer.serialize(PostView, data, nil)
     assert encoded[:links][:self] == PostView.url_for(data, nil)
-
-    assert encoded[:links][:next] ==
-             PostView.url_for_pagination(data, nil, %{cursor: "some-string"})
+    assert encoded[:links][:next]
 
     encoded_data = encoded[:data]
     assert encoded_data[:id] == PostView.id(data)
@@ -442,5 +440,22 @@ defmodule JSONAPISerializerTest do
     refute encoded[:links]
 
     Application.delete_env(:jsonapi, :remove_links)
+  end
+
+  test "serialize includes pagination links if they are defined" do
+    data = %{id: 1}
+
+    encoded = Serializer.serialize(PostView, data, nil)
+
+    assert encoded[:links][:next] ==
+             PostView.url_for_pagination(data, nil, %{cursor: "some-string"})
+  end
+
+  test "serialize does not include pagination links if they are not defined" do
+    data = %{id: 1}
+
+    encoded = Serializer.serialize(UserView, data, nil)
+
+    refute encoded[:links][:next]
   end
 end


### PR DESCRIPTION
Why:

* The JSON:API spec supports pagination by adding links to the top level
  links object. The URL itself has only one restriction, which is that
  the query params names need to all be within the `page` array.

This change addresses the need by:

* Allowing the view to override a `links` function which should return a
  map with the urls to be appended. Note that there is nothing specific
  about pagination here.
* Adding `url_for_pagination` a helper function to more easily create
  JSON:API compliant pagination urls.