### PR TITLE
Handle dashed include for top-level relationship

### DIFF
--- a/lib/jsonapi/query_parser.ex
+++ b/lib/jsonapi/query_parser.ex
@@ -181,7 +181,7 @@ defmodule JSONAPI.QueryParser do
       if inc =~ ~r/\w+\.\w+/ do
         acc ++ handle_nested_include(inc, valid_includes, config)
       else
-        inc = String.to_atom(inc)
+        inc = inc |> dash() |> String.to_existing_atom()
 
         if Enum.any?(valid_includes, fn {key, _val} -> key == inc end) do
           acc ++ [inc]

--- a/test/jsonapi_query_parser_test.exs
+++ b/test/jsonapi_query_parser_test.exs
@@ -11,7 +11,11 @@ defmodule JSONAPI.QueryParserTest do
     def type, do: "mytype"
 
     def relationships do
-      [author: JSONAPI.QueryParserTest.UserView, comments: JSONAPI.QueryParserTest.CommentView]
+      [
+        author: JSONAPI.QueryParserTest.UserView,
+        comments: JSONAPI.QueryParserTest.CommentView,
+        best_friends: JSONAPI.QueryParsertTest.UserView
+      ]
     end
   end
 
@@ -67,6 +71,7 @@ defmodule JSONAPI.QueryParserTest do
     assert parse_include(config, "author").includes == [:author]
     assert parse_include(config, "comments,author").includes == [:comments, :author]
     assert parse_include(config, "comments.user").includes == [comments: :user]
+    assert parse_include(config, "best_friends").includes == [:best_friends]
 
     assert_raise ArgumentError, "argument error", fn ->
       assert parse_include(config, "author.top-posts")
@@ -75,6 +80,7 @@ defmodule JSONAPI.QueryParserTest do
     Application.put_env(:jsonapi, :underscore_to_dash, true)
 
     assert parse_include(config, "author.top-posts").includes == [author: :top_posts]
+    assert parse_include(config, "best-friends").includes == [:best_friends]
 
     Application.delete_env(:jsonapi, :underscore_to_dash)
   end


### PR DESCRIPTION
Dashed includes were supported for nested relationships, but not for top-level ones. Also removes a stray `String.to_atom`