### PR TITLE
Allow list of hidden fields to be calculated based on current data map

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -107,7 +107,7 @@ defmodule JSONAPI.View do
       end
 
       def attributes(data, conn) do
-        visible_fields = fields() -- hidden()
+        visible_fields = fields() -- hidden(data)
 
         Enum.reduce(visible_fields, %{}, fn field, intermediate_map ->
           value =
@@ -126,7 +126,9 @@ defmodule JSONAPI.View do
 
       def fields, do: raise("Need to implement fields/0")
 
-      def hidden, do: []
+      def hidden(), do: []
+
+      def hidden(data \\ %{}), do: hidden()
 
       def show(model, conn, _params, meta \\ nil), do: serialize(__MODULE__, model, conn, meta)
       def index(models, conn, _params, meta \\ nil), do: serialize(__MODULE__, models, conn, meta)
@@ -180,6 +182,7 @@ defmodule JSONAPI.View do
       defoverridable attributes: 2,
                      fields: 0,
                      hidden: 0,
+                     hidden: 1,
                      id: 1,
                      meta: 2,
                      relationships: 0,

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -128,7 +128,7 @@ defmodule JSONAPI.View do
 
       def hidden(), do: []
 
-      def hidden(data \\ %{}), do: hidden()
+      def hidden(data), do: hidden()
 
       def show(model, conn, _params, meta \\ nil), do: serialize(__MODULE__, model, conn, meta)
       def index(models, conn, _params, meta \\ nil), do: serialize(__MODULE__, models, conn, meta)

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -128,7 +128,7 @@ defmodule JSONAPI.View do
 
       def hidden(), do: []
 
-      def hidden(data), do: hidden()
+      def hidden(_data), do: hidden()
 
       def show(model, conn, _params, meta \\ nil), do: serialize(__MODULE__, model, conn, meta)
       def index(models, conn, _params, meta \\ nil), do: serialize(__MODULE__, models, conn, meta)

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -49,7 +49,7 @@ defmodule JSONAPI.ViewTest do
     end
 
     def hidden(data) do
-      [:password] |> hide_if_nil(data, :age)
+      hide_if_nil([:password], data, :age)
     end
 
     def hide_if_nil(hidden, data, field) do


### PR DESCRIPTION
Hi again 👋 

I'm publishing a swagger/openapi 2.0 spec for my jsonapi. I have a timestamp that may be nil. Swagger 2.0 doesn't support nullable fields. Instead, swagger wants me to include or omit the timestamp from the response based on whether it exists or is nil.

This PR adds a `hidden/1` function to `JSONAPI.View` that accepts the view's `data` as a parameter. By default, it just calls `hidden/0` to preserve existing functionality (so you can still override `hidden/0` and provide a static list of fields). If you override `hidden/1`, then you can consider the current data object when you are producing the list of hidden fields.

What do you think of this feature/approach?