### PR TITLE
Xarango id is in _key not id

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -98,6 +98,7 @@ defmodule JSONAPI.View do
 
       def id(nil), do: nil
       def id(%{__struct__: Ecto.Association.NotLoaded}), do: nil
+      def id(%{_key: id}), do: to_string(id)
       def id(%{id: id}), do: to_string(id)
 
       if @resource_type do


### PR DESCRIPTION
This will grab the _key (which is id in arangodb) and use it as the id.

_id in arangodb is collection/key