### PR TITLE
Corrects the format validation plug

### DIFF
--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -9,9 +9,7 @@ defmodule JSONAPI.FormatRequired do
 
   def call(%{method: method} = conn, _opts) when method in ["DELETE", "GET", "HEAD"], do: conn
 
-  def call(%{method: method, params: %{"data" => %{"type" => _}}} = conn, _)
-      when method == "POST",
-      do: conn
+  def call(%{method: "POST", params: %{"data" => %{"type" => _}}} = conn, _), do: conn
 
   def call(%{params: %{"data" => %{"type" => _, "id" => _}}} = conn, _), do: conn
 

--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -8,8 +8,12 @@ defmodule JSONAPI.FormatRequired do
   def init(opts), do: opts
 
   def call(%{method: method} = conn, _opts) when method in ["DELETE", "GET", "HEAD"], do: conn
-  def call(%{params: %{"data" => %{"relationships" => _}}} = conn, _), do: conn
-  def call(%{params: %{"data" => %{"attributes" => _}}} = conn, _), do: conn
+
+  def call(%{method: method, params: %{"data" => %{"type" => _}}} = conn, _)
+      when method == "POST",
+      do: conn
+
+  def call(%{params: %{"data" => %{"type" => _, "id" => _}}} = conn, _), do: conn
 
   def call(%{params: %{"data" => _}} = conn, _),
     do: send_error(conn, missing_data_attributes_param())

--- a/test/jsonapi/plugs/format_required_test.exs
+++ b/test/jsonapi/plugs/format_required_test.exs
@@ -35,10 +35,28 @@ defmodule JSONAPI.FormatRequiredTest do
            } = error
   end
 
-  test "does not halt if only relationships member is present" do
+  test "does not halt if only type member is present on a post" do
     conn =
       :post
-      |> conn("/example", Jason.encode!(%{data: %{relationships: %{}}}))
+      |> conn("/example", Jason.encode!(%{data: %{type: "something"}}))
+      |> call_plug
+
+    refute conn.halted
+  end
+
+  test "halts if only type member is present on a patch" do
+    conn =
+      :patch
+      |> conn("/example", Jason.encode!(%{data: %{type: "something"}}))
+      |> call_plug
+
+    assert conn.halted
+  end
+
+  test "does not halt if type and id members are present on a patch" do
+    conn =
+      :patch
+      |> conn("/example", Jason.encode!(%{data: %{type: "something", id: "some-identifier"}}))
       |> call_plug
 
     refute conn.halted
@@ -47,7 +65,7 @@ defmodule JSONAPI.FormatRequiredTest do
   test "passes request through" do
     conn =
       :post
-      |> conn("/example", Jason.encode!(%{data: %{attributes: %{}}}))
+      |> conn("/example", Jason.encode!(%{data: %{type: "something"}}))
       |> call_plug
 
     refute conn.halted


### PR DESCRIPTION
Why:

* Currently we're validating a POST or PATCH request if it has either an
  attributes or relationships member. However, there is nothing in the
  spec (as far as I'm able to understand) that enforces this. Moreover,
  it does say that type is required for POSTs and type and id are
  required for PATCHs, which we are not validating.

This change addresses the need by:

* Taking this into account and refactoring the plug to correctly
  validate the format of requests.