### PR TITLE
Omit non-Object meta

### DIFF
--- a/lib/jsonapi/query_parser.ex
+++ b/lib/jsonapi/query_parser.ex
@@ -117,8 +117,7 @@ defmodule JSONAPI.QueryParser do
       requested_fields =
         value
         |> String.split(",")
-        |> Enum.map(&String.to_atom/1)
-        |> Enum.into(MapSet.new())
+        |> Enum.into(MapSet.new(), &String.to_atom/1)
 
       unless MapSet.subset?(requested_fields, valid_fields) do
         bad_fields =

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -25,9 +25,14 @@ defmodule JSONAPI.Serializer do
 
     encoded_data = %{
       data: encoded_data,
-      included: flatten_included(to_include),
-      meta: meta
+      included: flatten_included(to_include)
     }
+
+    encoded_data =
+      case meta do
+        nil -> encoded_data
+        ^meta -> Map.put(encoded_data, :meta, meta)
+      end
 
     merge_links(encoded_data, data, view, conn, remove_links?(), with_pagination?())
   end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -29,9 +29,10 @@ defmodule JSONAPI.Serializer do
     }
 
     encoded_data =
-      case meta do
-        nil -> encoded_data
-        ^meta -> Map.put(encoded_data, :meta, meta)
+      if is_map(meta) do
+        Map.put(encoded_data, :meta, meta)
+      else
+        encoded_data
       end
 
     merge_links(encoded_data, data, view, conn, remove_links?(), with_pagination?())

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -24,9 +24,7 @@ defmodule JSONAPI.Utils.Underscore do
   end
 
   def underscore(value) when is_map(value) do
-    value
-    |> Enum.map(&underscore/1)
-    |> Enum.into(%{})
+    Enum.into(value, %{}, &underscore/1)
   end
 
   def underscore({key, value}) do

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -272,4 +272,45 @@ defmodule JSONAPITest do
 
     assert Map.has_key?(json, "links")
   end
+
+  test "omits explicit nil meta values as per http://jsonapi.org/format/#document-meta" do
+    conn =
+      :get
+      |> conn("/posts")
+      |> Plug.Conn.assign(:data, [
+        %{
+          id: 1,
+          text: "Hello",
+          body: "Hi",
+          author: %{username: "jason", id: 2},
+          other_user: %{username: "josh", id: 3}
+        }
+      ])
+      |> Plug.Conn.assign(:meta, nil)
+      |> MyPostPlug.call([])
+
+    json = conn.resp_body |> Jason.decode!()
+
+    refute Map.has_key?(json, "meta")
+  end
+
+  test "omits implicit nil meta values as per http://jsonapi.org/format/#document-meta" do
+    conn =
+      :get
+      |> conn("/posts")
+      |> Plug.Conn.assign(:data, [
+        %{
+          id: 1,
+          text: "Hello",
+          body: "Hi",
+          author: %{username: "jason", id: 2},
+          other_user: %{username: "josh", id: 3}
+        }
+      ])
+      |> MyPostPlug.call([])
+
+    json = conn.resp_body |> Jason.decode!()
+
+    refute Map.has_key?(json, "meta")
+  end
 end

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -2,6 +2,14 @@ defmodule JSONAPITest do
   use ExUnit.Case
   use Plug.Test
 
+  @default_data %{
+    id: 1,
+    text: "Hello",
+    body: "Hi",
+    author: %{username: "jason", id: 2},
+    other_user: %{username: "josh", id: 3}
+  }
+
   defmodule PostView do
     use JSONAPI.View
 
@@ -83,15 +91,7 @@ defmodule JSONAPITest do
     conn =
       :get
       |> conn("/posts")
-      |> Plug.Conn.assign(:data, [
-        %{
-          id: 1,
-          text: "Hello",
-          body: "Hi",
-          author: %{username: "jason", id: 2},
-          other_user: %{username: "josh", id: 3}
-        }
-      ])
+      |> Plug.Conn.assign(:data, [@default_data])
       |> Plug.Conn.assign(:meta, %{total_pages: 1})
       |> MyPostPlug.call([])
 
@@ -133,15 +133,7 @@ defmodule JSONAPITest do
   test "handles includes properly" do
     conn =
       conn(:get, "/posts?include=other_user")
-      |> Plug.Conn.assign(:data, [
-        %{
-          id: 1,
-          text: "Hello",
-          body: "Hi",
-          author: %{username: "jason", id: 2},
-          other_user: %{username: "josh", id: 3}
-        }
-      ])
+      |> Plug.Conn.assign(:data, [@default_data])
       |> Plug.Conn.fetch_query_params()
       |> MyPostPlug.call([])
 
@@ -277,15 +269,7 @@ defmodule JSONAPITest do
     conn =
       :get
       |> conn("/posts")
-      |> Plug.Conn.assign(:data, [
-        %{
-          id: 1,
-          text: "Hello",
-          body: "Hi",
-          author: %{username: "jason", id: 2},
-          other_user: %{username: "josh", id: 3}
-        }
-      ])
+      |> Plug.Conn.assign(:data, [@default_data])
       |> Plug.Conn.assign(:meta, nil)
       |> MyPostPlug.call([])
 
@@ -298,15 +282,7 @@ defmodule JSONAPITest do
     conn =
       :get
       |> conn("/posts")
-      |> Plug.Conn.assign(:data, [
-        %{
-          id: 1,
-          text: "Hello",
-          body: "Hi",
-          author: %{username: "jason", id: 2},
-          other_user: %{username: "josh", id: 3}
-        }
-      ])
+      |> Plug.Conn.assign(:data, [@default_data])
       |> MyPostPlug.call([])
 
     json = conn.resp_body |> Jason.decode!()


### PR DESCRIPTION
The serializer was including `meta` even in cases where its value would not be an Object, which is not in compliance with the JSONAPI spec (http://jsonapi.org/format/#document-meta). This PR makes the serializer omit the `meta` when `is_map(meta)` is `false`.

I also DRYed up the tests, since my added ones re-used some of the existing default data.