### PR TITLE
refactor: Content-type separtor use ';' instead of ','

### DIFF
--- a/lib/jsonapi/plugs/content_type_negotiation.ex
+++ b/lib/jsonapi/plugs/content_type_negotiation.ex
@@ -62,7 +62,7 @@ defmodule JSONAPI.ContentTypeNegotiation do
   end
 
   defp validate_header(string) when is_binary(string) do
-    string |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.member?(@jsonapi)
+    string |> String.split(";") |> Enum.map(&String.trim/1) |> Enum.member?(@jsonapi)
   end
 
   defp validate_header(nil), do: true


### PR DESCRIPTION
ref: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
