### PR TITLE
Revert "refactor: Content-type separtor use ';' instead of ',' (#127)"

### DIFF
--- a/lib/jsonapi/plugs/content_type_negotiation.ex
+++ b/lib/jsonapi/plugs/content_type_negotiation.ex
@@ -62,7 +62,7 @@ defmodule JSONAPI.ContentTypeNegotiation do
   end
 
   defp validate_header(string) when is_binary(string) do
-    string |> String.split(";") |> Enum.map(&String.trim/1) |> Enum.member?(@jsonapi)
+    string |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.member?(@jsonapi)
   end
 
   defp validate_header(nil), do: true


### PR DESCRIPTION
This reverts commit 2694b02b2a87bbbebcb6045a65d2bafa30fc0f64.

@toyah Lmk if you have any thoughts

See #127 for discussion on current use of `;` and `,`

Close #123 
