### PR TITLE
Removes warning about hidden being undefined

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -110,7 +110,8 @@ defmodule JSONAPI.View do
         hidden =
           if Enum.member?(__MODULE__.__info__(:functions), {:hidden, 0}) do
             Deprecation.warn(:hidden)
-            __MODULE__.hidden()
+            this = __MODULE__
+            this.hidden()
           else
             hidden(data)
           end


### PR DESCRIPTION
Why:

* When compiling a view that used this module it would throw a warning
  saying that `hidden/0` was undefined

This change addresses the need by:

* Tricking the compiler to now throw the warning since we know that it
  will be defined as we're only calling it conditionally on the fact that
  it has been overridden.