### PR TITLE
Globally configurable namespace

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -88,7 +88,8 @@ defmodule JSONAPI.View do
   """
   defmacro __using__(opts \\ []) do
     {type, opts} = Keyword.pop(opts, :type)
-    {namespace, _opts} = Keyword.pop(opts, :namespace, "")
+    {module_namespace, _opts} = Keyword.pop(opts, :namespace)
+    namespace = module_namespace || Application.get_env(:jsonapi, :namespace, "")
 
     quote do
       import JSONAPI.Serializer, only: [serialize: 4]

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -1,8 +1,6 @@
 defmodule JSONAPI.ViewTest do
   use ExUnit.Case
 
-  Application.put_env(:jsonapi, :namespace, "/other-api")
-
   setup tags do
     if tags[:compile_phoenix] do
       Module.create(Phoenix, [], __ENV__)
@@ -63,12 +61,6 @@ defmodule JSONAPI.ViewTest do
 
     assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) ==
              "http://www.example.com/api/posts/1/relationships/comments"
-
-    assert UserView.url_for(nil, nil) == "/other-api/users"
-    assert UserView.url_for([], nil) == "/other-api/users"
-    assert UserView.url_for(%{id: 1}, nil) == "/other-api/users/1"
-    assert UserView.url_for([], %Plug.Conn{}) == "http://www.example.com/other-api/users"
-    assert UserView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.example.com/other-api/users/1"
 
     Application.put_env(:jsonapi, :host, "www.otherhost.com")
     assert PostView.url_for([], %Plug.Conn{}) == "http://www.otherhost.com/api/posts"

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -1,6 +1,8 @@
 defmodule JSONAPI.ViewTest do
   use ExUnit.Case
 
+  Application.put_env(:jsonapi, :namespace, "/other-api")
+
   setup tags do
     if tags[:compile_phoenix] do
       Module.create(Phoenix, [], __ENV__)
@@ -28,9 +30,7 @@ defmodule JSONAPI.ViewTest do
   end
 
   defmodule UserView do
-    use JSONAPI.View,
-      type: "users",
-      namespace: "/api"
+    use JSONAPI.View, type: "users"
 
     def fields do
       [:age, :first_name, :last_name, :full_name, :password]
@@ -63,6 +63,12 @@ defmodule JSONAPI.ViewTest do
 
     assert PostView.url_for_rel(%{id: 1}, "comments", %Plug.Conn{}) ==
              "http://www.example.com/api/posts/1/relationships/comments"
+
+    assert UserView.url_for(nil, nil) == "/other-api/users"
+    assert UserView.url_for([], nil) == "/other-api/users"
+    assert UserView.url_for(%{id: 1}, nil) == "/other-api/users/1"
+    assert UserView.url_for([], %Plug.Conn{}) == "http://www.example.com/other-api/users"
+    assert UserView.url_for(%{id: 1}, %Plug.Conn{}) == "http://www.example.com/other-api/users/1"
 
     Application.put_env(:jsonapi, :host, "www.otherhost.com")
     assert PostView.url_for([], %Plug.Conn{}) == "http://www.otherhost.com/api/posts"


### PR DESCRIPTION
Why:

* A lot of the times a namespace is defined is to add the `/api` prefix
  to all the routes, and having to add it to all the views becomes tedious
  and error prone

This change addresses the need by:

* Allowing the namespace to be defined in a global config as a default
  that can be changed on a module by module basis