### PR TITLE
WIP: Allow :only and :except when enabling underscore_to_dash

### DIFF
--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -3,7 +3,7 @@ defmodule JSONAPI.Utils.Underscore do
   Helpers for replacing underscores with dashes.
   """
 
-  def underscore?, do: Application.get_env(:jsonapi, :underscore_to_dash, false) != false
+  def underscore?, do: config() != false
 
   @doc """
   Replace dashes between words in `value` with underscores
@@ -72,8 +72,7 @@ defmodule JSONAPI.Utils.Underscore do
   end
 
   defp underscore?(key) do
-    config = Application.get_env(:jsonapi, :underscore_to_dash)
-    config_specifies_underscore?(config, key)
+    config_specifies_underscore?(config(), key)
   end
 
   defp config_specifies_underscore?(true, _), do: true
@@ -87,4 +86,5 @@ defmodule JSONAPI.Utils.Underscore do
     end
   end
 
+  defp config, do: Application.get_env(:jsonapi, :underscore_to_dash, false)
 end

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -44,7 +44,7 @@ defmodule JSONAPI.Utils.Underscore do
   def underscore(value) when is_atom(value) do
     if underscore?(value) do
       value
-      |> to_string
+      |> to_string()
       |> underscore()
     else
       to_string(value)
@@ -60,16 +60,12 @@ defmodule JSONAPI.Utils.Underscore do
   end
 
   def underscore(value) when is_map(value) do
-    Enum.into(value, %{}, &underscore(&1))
+    Enum.into(value, %{}, &underscore/1)
   end
 
   def underscore({key, value}) do
-    if underscore?(key) do
-      if is_map(value) do
-        {underscore(key), underscore(value)}
-      else
-        {underscore(key), value}
-      end
+    if underscore?(key) and is_map(value) do
+      {underscore(key), underscore(value)}
     else
       {underscore(key), value}
     end
@@ -91,13 +87,7 @@ defmodule JSONAPI.Utils.Underscore do
     end
   end
 
-  defp config_specifies?(config, only_or_except, key) when is_list(config) do
-    case Keyword.get(config, only_or_except) do
-      list when is_list(list) ->
-        Enum.member?(list, key)
-
-      _ ->
-        false
-    end
+  defp config_specifies?(config, only_or_except, key) do
+    key in Keyword.get(config, only_or_except, [])
   end
 end

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -80,14 +80,11 @@ defmodule JSONAPI.Utils.Underscore do
   defp config_specifies_underscore?(false, _), do: false
 
   defp config_specifies_underscore?(config, key) when is_list(config) do
-    if Keyword.has_key?(config, :only) do
-      config_specifies?(config, :only, key)
-    else
-      !config_specifies?(config, :except, key)
+    cond do
+      Keyword.has_key?(config, :only) -> key in Keyword.get(config, :only, [])
+      Keyword.has_key?(config, :except) -> key not in Keyword.get(config, :except, [])
+      true -> false
     end
   end
 
-  defp config_specifies?(config, only_or_except, key) do
-    key in Keyword.get(config, only_or_except, [])
-  end
 end

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -81,7 +81,7 @@ defmodule JSONAPI.Utils.Underscore do
   defp config_specifies_underscore?(config, key) when is_list(config) do
     cond do
       Keyword.has_key?(config, :only) -> key in Keyword.get(config, :only, [])
-      Keyword.has_key?(config, :except) -> key not in Keyword.get(config, :except, [])
+      Keyword.has_key?(config, :except) -> not key in Keyword.get(config, :except, [])
       true -> false
     end
   end

--- a/test/jsonapi_query_parser_test.exs
+++ b/test/jsonapi_query_parser_test.exs
@@ -14,7 +14,9 @@ defmodule JSONAPI.QueryParserTest do
       [
         author: JSONAPI.QueryParserTest.UserView,
         comments: JSONAPI.QueryParserTest.CommentView,
-        best_friends: JSONAPI.QueryParsertTest.UserView
+        best_friends: JSONAPI.QueryParsertTest.UserView,
+        _private_friend: JSONAPI.QueryParserTest.UserView,
+        nonstandard__friend: JSONAPI.QueryParserTest.UserView
       ]
     end
   end
@@ -93,6 +95,8 @@ defmodule JSONAPI.QueryParserTest do
       config = struct(Config, view: MyView)
       assert parse_include(config, "author.top-posts").includes == [author: :top_posts]
       assert parse_include(config, "best-friends").includes == [:best_friends]
+      assert parse_include(config, "_private-friend").includes == [:_private_friend]
+      assert parse_include(config, "nonstandard__friend").includes == [:nonstandard__friend]
     end
   end
 

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -41,6 +41,7 @@ defmodule JSONAPISerializerTest do
       ]
 
     def meta(data, _conn), do: %{meta_text: "meta_#{data[:text]}"}
+
     def type, do: "mytype"
 
     def relationships do

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -456,7 +456,9 @@ defmodule JSONAPISerializerTest do
 
   describe "when underscore_to_dash: except" do
     setup do
-      Application.put_env(:jsonapi, :underscore_to_dash,
+      Application.put_env(
+        :jsonapi,
+        :underscore_to_dash,
         except: [:full_description, :_private_attribute, :metadata]
       )
 
@@ -518,7 +520,9 @@ defmodule JSONAPISerializerTest do
 
   describe "when underscore_to_dash: only" do
     setup do
-      Application.put_env(:jsonapi, :underscore_to_dash,
+      Application.put_env(
+        :jsonapi,
+        :underscore_to_dash,
         only: [:full_description, :inserted_at, :last_name]
       )
 


### PR DESCRIPTION
Fix for #132 

This adds the option to specify

```elixir
underscore_to_dash:
  only: [:all_my, :special_keys]
```

or

```elixir
underscore_to_dash:
  except: [:all_my, :special_keys]
```

For serialization the tests are pretty solid. I haven't built out the various edge case tests for query parsing yet. Thought I'd get some feedback first.

Notes:

1. I modified the `underscore` functions to accept a view, but the view is just ignored right now. I was thinking it would be nice to be able to specify keys per-view. I couldn't come up with a great way to configure that, so that view just gets passed along, and doesn't do anything yet. But it's ready and waiting. One option would be to allow for `{ViewModule, :special_key}` tuples in the Application.env lists. Any thought on this?

2. The current behavior is that when the config specifies keys, both the key and its value gets the same treatment. So if a key is in the `only` list, then it and its value are run through the `underscore` function. If not, neither the key nor the value are. Similarly for the `except` list.

3. I haven't done any testing for the scenario where a user might specify both `only` and `except`, but if `only` is present, it will win, and except will be ignored.

4. I added some `describe` blocks around the tests that modify `Application.env`, so that we can unset the changes in an on_exit block. This makes the tests more reliable when there are failures (i.e. the Application.env doesn't leak into other tests)