### PR TITLE
Update regexes for underscore and dash

### DIFF
--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -5,10 +5,42 @@ defmodule JSONAPI.Utils.Underscore do
 
   def underscore?, do: Application.get_env(:jsonapi, :underscore_to_dash, false)
 
+  @doc """
+  Replace dashes between words in `value` with underscores
+
+  Ignores dashes that are not between letters/numbers
+
+  ## Examples
+
+      iex> dash("top-posts")
+      "top_posts"
+
+      iex> dash("-top-posts")
+      "-top_posts"
+
+      iex> dash("-top--posts-")
+      "-top--posts-"
+  """
   def dash(value) when is_binary(value) do
     String.replace(value, ~r/([a-zA-Z0-9])-([a-zA-Z0-9])/, "\\1_\\2")
   end
 
+  @doc """
+  Replace underscores between words in `value` with dashes
+
+  Ignores underscores that are not between letters/numbers
+
+  ## Examples
+
+      iex> underscore("top_posts")
+      "top-posts"
+
+      iex> underscore("_top_posts")
+      "_top-posts"
+
+      iex> underscore("_top__posts_")
+      "_top__posts_"
+  """
   def underscore(value) when is_atom(value) do
     value
     |> to_string

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -6,7 +6,7 @@ defmodule JSONAPI.Utils.Underscore do
   def underscore?, do: Application.get_env(:jsonapi, :underscore_to_dash, false)
 
   def dash(value) when is_binary(value) do
-    String.replace(value, "-", "_")
+    String.replace(value, ~r/([a-zA-Z0-9])-([a-zA-Z0-9])/, "\\1_\\2")
   end
 
   def underscore(value) when is_atom(value) do
@@ -16,7 +16,7 @@ defmodule JSONAPI.Utils.Underscore do
   end
 
   def underscore(value) when is_binary(value) do
-    String.replace(value, "_", "-")
+    String.replace(value, ~r/([a-zA-Z0-9])_([a-zA-Z0-9])/, "\\1-\\2")
   end
 
   def underscore(%{__struct__: _} = value) when is_map(value) do

--- a/test/utils/underscore_test.exs
+++ b/test/utils/underscore_test.exs
@@ -1,0 +1,9 @@
+defmodule JSONAPI.Utils.UnderscoreTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  import JSONAPI.Utils.Underscore
+
+  doctest JSONAPI.Utils.Underscore
+end


### PR DESCRIPTION
Only match a single underscore/dash in the middle of word characters.
Makes the replacement less zealous.

Extracted from #137 