### PR TITLE
Set `Content-Type` for Errors

### DIFF
--- a/lib/jsonapi/error_view.ex
+++ b/lib/jsonapi/error_view.ex
@@ -2,7 +2,7 @@ defmodule JSONAPI.ErrorView do
   @moduledoc """
   """
 
-  import Plug.Conn, only: [send_resp: 3, halt: 1]
+  import Plug.Conn, only: [send_resp: 3, halt: 1, put_resp_content_type: 2]
 
   @crud_message "Check out http://jsonapi.org/format/#crud for more info."
 
@@ -69,6 +69,7 @@ defmodule JSONAPI.ErrorView do
 
   def send_error(conn, status, error) do
     conn
+    |> put_resp_content_type("application/vnd.api+json")
     |> send_resp(status, error)
     |> halt
   end

--- a/test/jsonapi/plugs/content_type_negotiation_test.exs
+++ b/test/jsonapi/plugs/content_type_negotiation_test.exs
@@ -171,4 +171,21 @@ defmodule JSONAPI.ContentTypeNegotiationTest do
     assert conn.halted
     assert 406 == conn.status
   end
+
+  test "returned error has correct content type" do
+    conn =
+      :post
+      |> conn("/example", "")
+      |> Plug.Conn.put_req_header(
+        "accept",
+        "application/vnd.api+json; version=1.0, application/vnd.api+json; version=1.0"
+      )
+      |> ContentTypeNegotiation.call([])
+
+    assert conn.halted
+
+    assert Plug.Conn.get_resp_header(conn, "content-type") == [
+             "application/vnd.api+json; charset=utf-8"
+           ]
+  end
 end


### PR DESCRIPTION
Prior to this change errors lacked this content type. This may confuse
some consumers of the API.