### PR TITLE
Expand build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: elixir
 
 elixir:
+  - 1.7
   - 1.6
   - 1.5
-  - 1.4
 
 otp_release:
-  - 20.1
+  - 21.1
+  - 20.3
   - 19.3
   - 18.3
 
@@ -14,6 +15,8 @@ matrix:
   exclude:
     - elixir: 1.6
       otp_release: 18.3
+    - elixir: 1.5
+      otp_release: 21.1
 
 env:
   global:
@@ -27,4 +30,4 @@ sudo: false
 script:
   - mix test
   - mix credo
-  - if [[ `elixir -v` = *"1.6"* ]]; then mix format --check-formatted; fi
+  - if ! [[ `elixir -v` = *"1.5"* ]]; then mix format --check-formatted; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ env:
 notifications:
   email: false
 
-sudo: false
-
 script:
   - mix test
   - mix credo


### PR DESCRIPTION
Going the opposite way of #150 by actually expanding the matrix to include the latest Elixir and OTP releases.  As mentioned on #150, we intentionally want multiple OTP releases so we can ensure the project compiles on different combinations of Elixir and OTP.