### PR TITLE
Refactor String Manipulation Utility Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ You will need to handle filtering yourself, the filter is just a map with key=va
 JSONAPI now recommends the use of dashes (`-`) in place of underscore (`_`) as a
 word separator. Handling these fields requires two steps:
 
-1. Dasherizing *outgoing* fields requires you to set the `underscore_to_dash`
-   configuration option. This is not enabled by default. Example:
+1. Dasherizing *outgoing* fields requires you to set the `:field_transformation`
+   configuration option. Example:
 
-    ```elixir
-    config :jsonapi,
-      underscore_to_dash: true,
-    ```
+   ```elixir
+   config :jsonapi,
+     field_transformation: :dasherize
+   ```
 
 2. Underscoring *incoming* params (both query and body) requires you add the
    `JSONAPI.UnderscoreParameters` Plug to your API's pipeline. Your pipeline in a
@@ -130,7 +130,8 @@ Under-the-hood `JSONAPI.EnsureSpec` relies on three individual plugs:
 config :jsonapi,
   host: "www.someotherhost.com",
   scheme: "https",
-  underscore_to_dash: true,
+  underscore_to_dash: true, # DEPRECATED
+  field_transformation: :underscore,
   remove_links: false,
   json_library: Jason
 ```
@@ -140,7 +141,14 @@ config :jsonapi,
 - **remove_links**. `links` data can optionally be removed from the payload via
   setting the configuration above to `true`. Defaults to `false`.
 - **json_library**. Defaults to [Jason](https://hex.pm/packages/jason).
-- **underscore_to_dash**. See "Dasherizing Fields".
+- **field_transformation**. This option describes how your API's fields word
+  boundaries are marked. JSON:API v1 recommends using a dash (e.g.
+  `"favorite-color": blue`). If your API uses dashed fields, set this value to
+  `:dasherize`. If your API uses underscores (e.g. `"favorite_color": "red"`)
+  set to `:underscore`.
+- **underscore_to_dash**. This is a deprecated option that previously defaulted
+  to `false`. Please set the appropriate value on the `field_transformation`
+  configuration option.
 
 ## Other
 

--- a/lib/jsonapi/deprecation.ex
+++ b/lib/jsonapi/deprecation.ex
@@ -27,4 +27,11 @@ defmodule JSONAPI.Deprecation do
       Macro.Env.stacktrace(__ENV__)
     )
   end
+
+  def warn(:underscore_to_dash) do
+    IO.warn(
+      "`:underscore_to_dash` is deprecated. If you want underscored fields, set `:field_transformation` to :underscore. If you want your fields to be dashed, set to :dasherized",
+      Macro.Env.stacktrace(__ENV__)
+    )
+  end
 end

--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -33,7 +33,7 @@ defmodule JSONAPI.UnderscoreParameters do
 
   import Plug.Conn
 
-  import JSONAPI.Utils.Underscore, only: [dash: 1]
+  import JSONAPI.Utils.String, only: [underscore: 1]
 
   @doc false
   def init(_opts) do
@@ -44,7 +44,7 @@ defmodule JSONAPI.UnderscoreParameters do
     content_type = get_req_header(conn, "content-type")
 
     if JSONAPI.mime_type() in content_type do
-      new_params = dash(params)
+      new_params = underscore(params)
 
       Map.put(conn, :params, new_params)
     else

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -4,7 +4,9 @@ defmodule JSONAPI.Serializer do
   """
 
   import JSONAPI.Ecto, only: [assoc_loaded?: 1]
-  alias JSONAPI.Utils.Underscore
+
+  alias JSONAPI.Utils.String, as: JString
+
   require Logger
 
   @doc """
@@ -51,7 +53,7 @@ defmodule JSONAPI.Serializer do
     encoded_data = %{
       id: view.id(data),
       type: view.type(),
-      attributes: underscore(view.attributes(data, conn)),
+      attributes: transform_fields(view.attributes(data, conn)),
       relationships: %{}
     }
 
@@ -88,7 +90,7 @@ defmodule JSONAPI.Serializer do
 
     only_rel_view = get_view(rel_view)
     # Build the relationship url
-    rel_key = underscore(key)
+    rel_key = transform_fields(key)
     rel_url = view.url_for_rel(data, rel_key, conn)
     # Build the relationship
     acc =
@@ -224,14 +226,14 @@ defmodule JSONAPI.Serializer do
   def get_view({view, :include}), do: view
   def get_view(view), do: view
 
-  def underscore(data) do
-    if Underscore.underscore?() do
-      Underscore.underscore(data)
-    else
-      data
-    end
-  end
-
   defp remove_links?, do: Application.get_env(:jsonapi, :remove_links, false)
   defp with_pagination?, do: Application.get_env(:jsonapi, :with_pagination, false)
+
+  defp transform_fields(fields) do
+    if JString.field_transformation() == :dasherize do
+      JString.dasherize(fields)
+    else
+      fields
+    end
+  end
 end

--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -1,0 +1,153 @@
+defmodule JSONAPI.Utils.String do
+  @moduledoc """
+  String manipulation helpers.
+  """
+
+  alias JSONAPI.Deprecation
+
+  @allowed_transformations [:dasherize, :underscore]
+
+  @doc """
+  Replace dashes between words in `value` with underscores
+
+  Ignores dashes that are not between letters/numbers
+
+  ## Examples
+
+      iex> underscore("top-posts")
+      "top_posts"
+
+      iex> underscore("-top-posts")
+      "-top_posts"
+
+      iex> underscore("-top--posts-")
+      "-top--posts-"
+
+      iex> underscore(%{"foo-bar" => "baz"})
+      %{"foo_bar" => "baz"}
+
+      iex> underscore({"foo-bar", "dollar-sol"})
+      {"foo_bar", "dollar-sol"}
+
+      iex> underscore({"foo-bar", %{"a-d" => "z-8"}})
+      {"foo_bar", %{"a_d" => "z-8"}}
+
+      iex> underscore(%{"f-b" => %{"a-d" => "z"}, "c-d" => "e"})
+      %{"f_b" => %{"a_d" => "z"}, "c_d" => "e"}
+
+      iex> underscore(:"foo-bar")
+      :foo_bar
+
+      iex> underscore(%{"f-b" => "a-d"})
+      %{"f_b" => "a-d"}
+  """
+  def underscore(value) when is_binary(value) do
+    String.replace(value, ~r/([a-zA-Z0-9])-([a-zA-Z0-9])/, "\\1_\\2")
+  end
+
+  def underscore(map) when is_map(map) do
+    Enum.into(map, %{}, &underscore/1)
+  end
+
+  def underscore({key, value}) when is_map(value) do
+    {underscore(key), underscore(value)}
+  end
+
+  def underscore({key, value}) do
+    {underscore(key), value}
+  end
+
+  def underscore(value) when is_atom(value) do
+    value
+    |> to_string()
+    |> underscore()
+    |> String.to_atom()
+  end
+
+  def underscore(value) do
+    value
+  end
+
+  @doc """
+  Replace underscores between words in `value` with dashes
+
+  Ignores underscores that are not between letters/numbers
+
+  ## Examples
+
+      iex> dasherize("top_posts")
+      "top-posts"
+
+      iex> dasherize("_top_posts")
+      "_top-posts"
+
+      iex> dasherize("_top__posts_")
+      "_top__posts_"
+  """
+  def dasherize(value) when is_atom(value) do
+    value
+    |> to_string()
+    |> dasherize()
+  end
+
+  def dasherize(value) when is_binary(value) do
+    String.replace(value, ~r/([a-zA-Z0-9])_([a-zA-Z0-9])/, "\\1-\\2")
+  end
+
+  def dasherize(%{__struct__: _} = value) when is_map(value) do
+    value
+  end
+
+  def dasherize(value) when is_map(value) do
+    Enum.into(value, %{}, &dasherize/1)
+  end
+
+  def dasherize({key, value}) do
+    if is_map(value) do
+      {dasherize(key), dasherize(value)}
+    else
+      {dasherize(key), value}
+    end
+  end
+
+  defp normalized_underscore_to_dash_config(value) when is_boolean(value) do
+    Deprecation.warn(:underscore_to_dash)
+
+    if value do
+      :dasherize
+    else
+      :underscore
+    end
+  end
+
+  defp normalized_underscore_to_dash_config(value) when is_nil(value), do: value
+
+  @doc """
+  The configured transformation for the API's fields. JSON:API v1 recommends
+  using dashed fields (e.g. "good-dog", versus "good_dog").
+
+  This library currently supports dashed and underscored fields.
+
+  ## Configuration examples
+
+  Dashed fields:
+
+  ```
+  config :jsonapi, field_transformation: :dasherize
+  ```
+
+  Underscored fields:
+
+  ```
+  config :jsonapi, field_transformation: :underscore
+  ```
+  """
+  def field_transformation do
+    normalized_underscore_to_dash_config(Application.get_env(:jsonapi, :underscore_to_dash)) ||
+      field_transformation(Application.get_env(:jsonapi, :field_transformation))
+  end
+
+  @doc false
+  def field_transformation(transformation) when transformation in @allowed_transformations,
+    do: transformation
+end

--- a/lib/jsonapi/utils/underscore.ex
+++ b/lib/jsonapi/utils/underscore.ex
@@ -1,110 +1,25 @@
 defmodule JSONAPI.Utils.Underscore do
   @moduledoc """
-  Helpers for replacing underscores with dashes.
+  DEPRECATED. Please Use `JSONAPI.Utils.String` instead.
   """
-
-  def underscore?, do: Application.get_env(:jsonapi, :underscore_to_dash, false)
 
   @doc """
   Replace dashes between words in `value` with underscores
 
   Ignores dashes that are not between letters/numbers
-
-  ## Examples
-
-      iex> dash("top-posts")
-      "top_posts"
-
-      iex> dash("-top-posts")
-      "-top_posts"
-
-      iex> dash("-top--posts-")
-      "-top--posts-"
-
-      iex> dash(%{"foo-bar" => "baz"})
-      %{"foo_bar" => "baz"}
-
-      iex> dash({"foo-bar", "dollar-sol"})
-      {"foo_bar", "dollar-sol"}
-
-      iex> dash({"foo-bar", %{"a-d" => "z-8"}})
-      {"foo_bar", %{"a_d" => "z-8"}}
-
-      iex> dash(%{"f-b" => %{"a-d" => "z"}, "c-d" => "e"})
-      %{"f_b" => %{"a_d" => "z"}, "c_d" => "e"}
-
-      iex> dash(:"foo-bar")
-      :foo_bar
-
-      iex> dash(%{"f-b" => "a-d"})
-      %{"f_b" => "a-d"}
   """
-  def dash(value) when is_binary(value) do
-    String.replace(value, ~r/([a-zA-Z0-9])-([a-zA-Z0-9])/, "\\1_\\2")
-  end
-
-  def dash(map) when is_map(map) do
-    Enum.into(map, %{}, &dash/1)
-  end
-
-  def dash({key, value}) when is_map(value) do
-    {dash(key), dash(value)}
-  end
-
-  def dash({key, value}) do
-    {dash(key), value}
-  end
-
-  def dash(value) when is_atom(value) do
-    value
-    |> to_string()
-    |> dash()
-    |> String.to_atom()
-  end
-
+  @deprecated "Use JSONAPI.Utils.String.underscore/1 instead"
   def dash(value) do
-    value
+    JSONAPI.Utils.String.underscore(value)
   end
 
   @doc """
   Replace underscores between words in `value` with dashes
 
   Ignores underscores that are not between letters/numbers
-
-  ## Examples
-
-      iex> underscore("top_posts")
-      "top-posts"
-
-      iex> underscore("_top_posts")
-      "_top-posts"
-
-      iex> underscore("_top__posts_")
-      "_top__posts_"
   """
-  def underscore(value) when is_atom(value) do
-    value
-    |> to_string
-    |> underscore
-  end
-
-  def underscore(value) when is_binary(value) do
-    String.replace(value, ~r/([a-zA-Z0-9])_([a-zA-Z0-9])/, "\\1-\\2")
-  end
-
-  def underscore(%{__struct__: _} = value) when is_map(value) do
-    value
-  end
-
-  def underscore(value) when is_map(value) do
-    Enum.into(value, %{}, &underscore/1)
-  end
-
-  def underscore({key, value}) do
-    if is_map(value) do
-      {underscore(key), underscore(value)}
-    else
-      {underscore(key), value}
-    end
+  @deprecated "Use JSONAPI.Utils.String.dasherize/1 instead"
+  def underscore(value) do
+    JSONAPI.Utils.String.dasherize(value)
   end
 end

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -81,8 +81,6 @@ defmodule JSONAPI.View do
 
     * `:scheme` (atom) - Enables configuration of the HTTP scheme for generated URLS.  Defaults to `scheme` from the provided `conn`.
 
-    * `:underscore_to_dash` (boolean) - Use dash (`-`) as the word separated for JSON in place of underscore (`_`) per the JSONAPI spec [recommendations](http://jsonapi.org/recommendations/).  Defaults to `false`.
-
   The default behaviour for `host` and `scheme` is to derive it from the `conn` provided, while the
   default style for presentation in names is to be underscored and not dashed.
   """

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -35,6 +35,16 @@ defmodule JSONAPI.QueryParserTest do
     def relationships, do: [user: JSONAPI.QueryParserTest.UserView]
   end
 
+  setup do
+    Application.put_env(:jsonapi, :field_transformation, :underscore)
+
+    on_exit(fn ->
+      Application.delete_env(:jsonapi, :field_transformation)
+    end)
+
+    {:ok, []}
+  end
+
   test "parse_sort/2 turns sorts into valid ecto sorts" do
     config = struct(Config, opts: [sort: ~w(name title)], view: MyView)
     assert parse_sort(config, "name,title").sort == [asc: :name, asc: :title]
@@ -78,12 +88,12 @@ defmodule JSONAPI.QueryParserTest do
     end
   end
 
-  describe "when underscore_to_dash == true" do
+  describe "when API configured for dashed fields" do
     setup do
-      Application.put_env(:jsonapi, :underscore_to_dash, true)
+      Application.put_env(:jsonapi, :field_transformation, :dasherize)
 
       on_exit(fn ->
-        Application.delete_env(:jsonapi, :underscore_to_dash)
+        Application.delete_env(:jsonapi, :field_transformation)
       end)
 
       {:ok, []}

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -43,6 +43,16 @@ defmodule JSONAPI.ViewTest do
 
   alias JSONAPI.ViewTest.CommentView
 
+  setup do
+    Application.put_env(:jsonapi, :field_transformation, :underscore)
+
+    on_exit(fn ->
+      Application.delete_env(:jsonapi, :field_transformation)
+    end)
+
+    {:ok, []}
+  end
+
   test "type/0 when specified via using macro" do
     assert PostView.type() == "posts"
   end

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -87,6 +87,16 @@ defmodule JSONAPITest do
     end
   end
 
+  setup do
+    Application.put_env(:jsonapi, :field_transformation, :underscore)
+
+    on_exit(fn ->
+      Application.delete_env(:jsonapi, :field_transformation)
+    end)
+
+    {:ok, []}
+  end
+
   test "handles simple requests" do
     conn =
       :get

--- a/test/serializer_test.exs
+++ b/test/serializer_test.exs
@@ -88,6 +88,16 @@ defmodule JSONAPISerializerTest do
     end
   end
 
+  setup do
+    Application.put_env(:jsonapi, :field_transformation, :underscore)
+
+    on_exit(fn ->
+      Application.delete_env(:jsonapi, :field_transformation)
+    end)
+
+    {:ok, []}
+  end
+
   test "serialize includes meta as top level member" do
     meta = %{total_pages: 10}
     encoded = Serializer.serialize(PostView, %{id: 1, text: "Hello"}, nil, meta)
@@ -358,18 +368,18 @@ defmodule JSONAPISerializerTest do
     assert Enum.count(encoded.included) == 4
   end
 
-  describe "when underscore_to_dash == true" do
+  describe "when configured to dasherize fields" do
     setup do
-      Application.put_env(:jsonapi, :underscore_to_dash, true)
+      Application.put_env(:jsonapi, :field_transformation, :dasherize)
 
       on_exit(fn ->
-        Application.delete_env(:jsonapi, :underscore_to_dash)
+        Application.delete_env(:jsonapi, :field_transformation)
       end)
 
       {:ok, []}
     end
 
-    test "serialize properly uses underscore_to_dash on both attributes and relationships" do
+    test "serialize properly dasherizes both attributes and relationships" do
       data = %{
         id: 1,
         text: "Hello",

--- a/test/utils/string_test.exs
+++ b/test/utils/string_test.exs
@@ -1,0 +1,41 @@
+defmodule JSONAPI.Utils.StringTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  import JSONAPI.Utils.String
+
+  doctest JSONAPI.Utils.String
+
+  describe "legacy configuration to dasherize fields" do
+    setup do
+      Application.put_env(:jsonapi, :underscore_to_dash, true)
+
+      on_exit(fn ->
+        Application.delete_env(:jsonapi, :underscore_to_dash)
+      end)
+
+      {:ok, []}
+    end
+
+    test "#field_transformation/0 returns :dasherize" do
+      assert field_transformation() == :dasherize
+    end
+  end
+
+  describe "legacy configuration to underscore fields" do
+    setup do
+      Application.put_env(:jsonapi, :underscore_to_dash, false)
+
+      on_exit(fn ->
+        Application.delete_env(:jsonapi, :underscore_to_dash)
+      end)
+
+      {:ok, []}
+    end
+
+    test "#field_transformation/0 returns :underscore" do
+      assert field_transformation() == :underscore
+    end
+  end
+end

--- a/test/utils/underscore_test.exs
+++ b/test/utils/underscore_test.exs
@@ -1,9 +1,0 @@
-defmodule JSONAPI.Utils.UnderscoreTest do
-  @moduledoc false
-
-  use ExUnit.Case, async: true
-
-  import JSONAPI.Utils.Underscore
-
-  doctest JSONAPI.Utils.Underscore
-end


### PR DESCRIPTION
* Introduces `Utils.StringManipulation` for holding any String
  manipulation functions
* Renames functions to have a more intuitive name
* Deprecates old module and corresponding functions
* Rolls in "safe" String manipulation methods into the new module

Deviations from RFC
-------------------

I ended up using the module name `StringManipulation` instead of `String`. I quickly ran into issues when trying to alias using the proposed name.

Resolves #153