### PR TITLE
Update ex_doc for release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule JSONAPI.Mixfile do
     [
       {:plug, "~> 1.0"},
       {:jason, "~> 1.0", optional: true},
-      {:ex_doc, "~> 0.7", only: :dev},
+      {:ex_doc, "~> 0.19", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:phoenix, "~> 1.3", only: :test}


### PR DESCRIPTION
@jherdman the release fails because we're using a very old `ex_doc`. This should fix that. Could you please review and approve?  Additionally, are you able to tag the release on GitHub? If so please do 😁 