### PR TITLE
Fully Support Sparse Fieldsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ defmodule MyApp.PostView do
 end
 ```
 
-is an example of a basic view. You can now call `render(conn, MyApp.PostView, "show.json", %{data: my_data, meta: meta})` or `'index.json` normally.
+You can now call `render(conn, MyApp.PostView, "show.json", %{data: my_data, meta: meta})`
+or `"index.json"` normally.
 
-If you'd like to use this without phoenix simply use the `JSONAPI.View` and call `JSONAPI.Serializer.serialize(MyApp.PostView, data, conn, meta)`.
+If you'd like to use this without Phoenix simply use the `JSONAPI.View` and call
+`JSONAPI.Serializer.serialize(MyApp.PostView, data, conn, meta)`.
 
 ## Parsing and validating a JSONAPI Request
 
@@ -71,18 +73,19 @@ plug JSONAPI.QueryParser,
   view: PostView
 ```
 
-This will add a `JSONAPI.Config` struct called `jsonapi_config` to your conn.assigns. If a user tries to
-sort, filter, include, or sparse fieldset an invalid field it will raise a plug error that shows the
-proper error message.
+This will add a `JSONAPI.Config` struct called `jsonapi_config` to your
+`conn.assigns`. If a user tries to sort, filter, include, or requests an
+invalid fieldset it will raise a `Plug` error that shows the proper error
+message.
 
-The config holds the values parsed into things that are easy to pass into an Ecto query, for example
+The config holds the values parsed into things that are easy to pass into an Ecto
+query, for example `sort=-name` will be parsed into `sort: [desc: :name]` which
+can be passed directly to the `order_by` in Ecto.
 
-`sort=-name` will be parsed into `sort: [desc: :name]` which can be passed directly to the order_by in ecto.
+This sort of behavior is consistent for includes.
 
-This sort of behavior is consistent for includes. Sparse fieldsets happen in the view using Map.take but
-when Ecto gets more complex field selection support we will go further to only query the data we need.
-
-You will need to handle filtering yourself, the filter is just a map with key=value.
+The `JSONAPI.QueryParser` plug also supports [sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets).
+Please see its documentation for details.
 
 ## Camelized or Dasherized Fields
 

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -119,6 +119,10 @@ defmodule JSONAPI.QueryParserTest do
     assert_raise InvalidQuery, "invalid fields, blag for type mytype", fn ->
       parse_fields(config, %{"mytype" => "blag"})
     end
+
+    assert_raise InvalidQuery, "invalid fields, username for type mytype", fn ->
+      parse_fields(config, %{"mytype" => "username"})
+    end
   end
 
   test "get_view_for_type/2" do


### PR DESCRIPTION
Whilst the `QueryParser` was correctly identifying requested fieldsets,
nothing was done to actually support this.

This change prunes returned fields to those requested should it be the
case.

Note that this change also includes a few more typespecs for functions I
touched or read.

Resolves #120 
Closes #156 