### PR TITLE
Remove `Config.required_fields`

### DIFF
--- a/lib/jsonapi/config.ex
+++ b/lib/jsonapi/config.ex
@@ -10,7 +10,6 @@ defmodule JSONAPI.Config do
             filter: [],
             include: [],
             opts: nil,
-            required_fields: nil,
             sort: nil,
             view: nil,
             page: %Page{}
@@ -21,7 +20,6 @@ defmodule JSONAPI.Config do
           filter: keyword,
           include: keyword,
           opts: nil | keyword,
-          required_fields: any,
           sort: nil | keyword,
           view: any,
           page: Page.t()


### PR DESCRIPTION
This parameter on `Config` has its origins in work done to parse
`"includes"` shown here: c794148465722369a562af7f5d521b2d51d20b07.

As far as I can tell this parameter is both undocumented and unused. It
should be completely safe to remove.