### PR TITLE
Globally Configurable Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Under-the-hood `JSONAPI.EnsureSpec` relies on three individual plugs:
 config :jsonapi,
   host: "www.someotherhost.com",
   scheme: "https",
+  namespace: "/api",
   field_transformation: :underscore,
   remove_links: false,
   json_library: Jason
@@ -140,6 +141,10 @@ config :jsonapi,
 
 - **host**, **scheme**. By default these are pulled from the `conn`, but may be
   overridden.
+- **namespace**. This optional setting can be used to configure the namespace
+  your resources live at (e.g. given "http://example.com/api/cars", `"/api"`
+  would be the namespace). See also `JSONAPI.View` for setting on the resource's
+  View itself.
 - **remove_links**. `links` data can optionally be removed from the payload via
   setting the configuration above to `true`. Defaults to `false`.
 - **json_library**. Defaults to [Jason](https://hex.pm/packages/jason).


### PR DESCRIPTION
Why:

* A lot of the times a namespace is defined is to add the `/api` prefix
  to all the routes, and having to add it to all the views becomes tedious
  and error prone

This change addresses the need by:

* Allowing the namespace to be defined in a global config as a default
  that can be changed on a module by module basis

Note
-----

This pull request supersedes #130 by @zamith . Big ups to @zamith for the original effort 💪 .