### PR TITLE
Report on missing data[type] as such

### DIFF
--- a/lib/jsonapi/error_view.ex
+++ b/lib/jsonapi/error_view.ex
@@ -40,6 +40,12 @@ defmodule JSONAPI.ErrorView do
     |> serialize_error
   end
 
+  def missing_data_type_param do
+    "Missing type in data parameter"
+    |> build_error(400, @crud_message, "/data/type")
+    |> serialize_error
+  end
+
   def missing_data_param do
     "Missing data parameter"
     |> build_error(400, @crud_message, "/data")

--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -25,6 +25,9 @@ defmodule JSONAPI.FormatRequired do
 
   def call(%{params: %{"data" => %{"type" => _, "id" => _}}} = conn, _), do: conn
 
+  def call(%{params: %{"data" => %{"attributes" => _}}} = conn, _),
+    do: send_error(conn, missing_data_type_param())
+
   def call(%{params: %{"data" => _}} = conn, _),
     do: send_error(conn, missing_data_attributes_param())
 

--- a/test/jsonapi/plugs/format_required_test.exs
+++ b/test/jsonapi/plugs/format_required_test.exs
@@ -35,6 +35,23 @@ defmodule JSONAPI.FormatRequiredTest do
            } = error
   end
 
+  test "halts and returns an error for missing type in data param" do
+    conn =
+      :post
+      |> conn("/example", Jason.encode!(%{data: %{attributes: %{}}}))
+      |> call_plug
+
+    assert conn.halted
+    assert 400 == conn.status
+
+    %{"errors" => [error]} = Jason.decode!(conn.resp_body)
+
+    assert %{
+             "source" => %{"pointer" => "/data/type"},
+             "title" => "Missing type in data parameter"
+           } = error
+  end
+
   test "does not halt if only type member is present on a post" do
     conn =
       :post


### PR DESCRIPTION
Passing in a payload with `data: %{attributes: %{}}` would result in an error message stating that `attributes` was missing from `data`, when in fact what was missing was `type`. This corrects that.