### PR TITLE
Change the key name for page numbers to number

### DIFF
--- a/lib/jsonapi/page.ex
+++ b/lib/jsonapi/page.ex
@@ -6,14 +6,14 @@ defmodule JSONAPI.Page do
   defstruct limit: nil,
             offset: nil,
             size: nil,
-            page: nil,
+            number: nil,
             cursor: nil
 
   @type t :: %__MODULE__{
           limit: nil | non_neg_integer,
           offset: nil | non_neg_integer,
           size: nil | non_neg_integer,
-          page: nil | non_neg_integer,
+          number: nil | non_neg_integer,
           cursor: nil | non_neg_integer
         }
 end

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -48,7 +48,7 @@ defmodule JSONAPI.QueryParser do
         page: %JSONAPI.Page{
           limit: limit,
           offset: offset,
-          page: page,
+          number: number,
           size: size,
           cursor: cursor
         }}

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -134,7 +134,7 @@ defmodule JSONAPI.QueryParserTest do
     assert parse_pagination(config, config.page).page.__struct__ == JSONAPI.Page
     assert parse_pagination(config, %{"limit" => 1}).page.limit == 1
     assert parse_pagination(config, %{"offset" => 1}).page.offset == 1
-    assert parse_pagination(config, %{"page" => 1}).page.page == 1
+    assert parse_pagination(config, %{"number" => 1}).page.number == 1
     assert parse_pagination(config, %{"size" => 1}).page.size == 1
     assert parse_pagination(config, %{"cursor" => 1}).page.cursor == 1
   end


### PR DESCRIPTION
According to the specification (https://jsonapi.org/format/#fetching-pagination) the page number should appear as `page[number]`, not `page[page]`. This PR fixes it.