### PR TITLE
Require ID for PATCH

### DIFF
--- a/lib/jsonapi/error_view.ex
+++ b/lib/jsonapi/error_view.ex
@@ -40,6 +40,12 @@ defmodule JSONAPI.ErrorView do
     |> serialize_error
   end
 
+  def missing_data_id_param do
+    "Missing id in data parameter"
+    |> build_error(400, @crud_message, "/data/id")
+    |> serialize_error
+  end
+
   def missing_data_type_param do
     "Missing type in data parameter"
     |> build_error(400, @crud_message, "/data/type")

--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -25,6 +25,10 @@ defmodule JSONAPI.FormatRequired do
 
   def call(%{params: %{"data" => %{"type" => _, "id" => _}}} = conn, _), do: conn
 
+  def call(%{method: "PATCH", params: %{"data" => %{"attributes" => _}}} = conn, _) do
+    send_error(conn, missing_data_id_param())
+  end
+
   def call(%{params: %{"data" => %{"attributes" => _}}} = conn, _),
     do: send_error(conn, missing_data_type_param())
 


### PR DESCRIPTION
Recently we've encountered an issue in which a PATCH payload that lacks an ID produces an incorrect error message stating that the `type` is what's missing.

This adds a new error that refers to `id`, and produces it in the cases we encountered.