### PR TITLE
Serializer Includes Links by Default

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,6 +53,7 @@ defmodule JSONAPI.Mixfile do
       {:earmark, ">= 0.0.0", only: :dev},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:phoenix, "~> 1.3", only: :test},
+      {:ecto, "~> 3.1", only: :test},
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev, :test], runtime: false}
     ]
   end

--- a/test/jsonapi/ecto_test.exs
+++ b/test/jsonapi/ecto_test.exs
@@ -1,0 +1,13 @@
+defmodule JSONAPI.EctoTest do
+  use ExUnit.Case, async: true
+
+  import JSONAPI.Ecto, only: [assoc_loaded?: 1]
+
+  describe "assoc_loaded?/1" do
+    test "checks if an Ecto Association is loaded" do
+      refute assoc_loaded?(%Ecto.Association.NotLoaded{})
+
+      assert assoc_loaded?(%{})
+    end
+  end
+end


### PR DESCRIPTION
Relationships will always, at the least, include a `"self"` link unless
`remove_links` has been configured.

This aligns us more closely with the spec. According to the spec a
relationship object MUST contain one of:

* `links`
* `data`
* `meta`

Before this change it was possible to generate an empty relationship
object. The cost of this is increased payload size, though I think most
users will find this OK.

Resolves #174