### PR TITLE
Use string status codes in error responses

### DIFF
--- a/lib/jsonapi/error_view.ex
+++ b/lib/jsonapi/error_view.ex
@@ -10,7 +10,7 @@ defmodule JSONAPI.ErrorView do
   def build_error(title, status, detail, pointer \\ nil, meta \\ nil) do
     error = %{
       detail: detail,
-      status: status,
+      status: Integer.to_string(status),
       title: title
     }
 
@@ -97,6 +97,10 @@ defmodule JSONAPI.ErrorView do
   def send_error(conn, status, error) when is_map(error) do
     json = JSONAPI.json_library().encode!(error)
     send_error(conn, status, json)
+  end
+
+  def send_error(conn, status, error) when is_binary(status) do
+    send_error(conn, String.to_integer(status), error)
   end
 
   def send_error(conn, status, error) do

--- a/test/jsonapi/plugs/format_required_test.exs
+++ b/test/jsonapi/plugs/format_required_test.exs
@@ -138,7 +138,7 @@ defmodule JSONAPI.FormatRequiredTest do
              "detail" =>
                "Check out https://jsonapi.org/format/#crud-updating-to-many-relationships for more info.",
              "source" => %{"pointer" => "/data"},
-             "status" => 400,
+             "status" => "400",
              "title" =>
                "Data parameter has multiple Resource Identifier Objects for a non-relationship endpoint"
            } = error


### PR DESCRIPTION
The [JSON:API spec for errors](https://jsonapi.org/format/#errors) says that the status should be "expressed as a string value" so this PR makes that change!
