### PR TITLE
Fix #207 problems with 'self' pagination link

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -161,7 +161,9 @@ defmodule JSONAPI.Serializer do
 
   defp merge_base_links(%{links: links} = doc, data, view, conn) do
     view_links =
-      Map.merge(%{self: view.url_for(data, conn)}, view.links(data, conn)) |> Map.merge(links)
+      %{self: view.url_for(data, conn)}
+      |> Map.merge(view.links(data, conn))
+      |> Map.merge(links)
 
     Map.merge(doc, %{links: view_links})
   end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -161,10 +161,7 @@ defmodule JSONAPI.Serializer do
 
   defp merge_base_links(%{links: links} = doc, data, view, conn) do
     view_links =
-      data
-      |> view.links(conn)
-      |> Map.merge(links)
-      |> Map.merge(%{self: view.url_for(data, conn)})
+      Map.merge(%{self: view.url_for(data, conn)}, view.links(data, conn)) |> Map.merge(links)
 
     Map.merge(doc, %{links: view_links})
   end

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -45,7 +45,8 @@ defmodule JSONAPI.SerializerTest do
         first: view.url_for_pagination(data, conn, %{page | "page" => "1"}),
         last: view.url_for_pagination(data, conn, %{page | "page" => total_pages}),
         next: next_link(data, view, conn, number, size, total_pages),
-        prev: previous_link(data, view, conn, number, size)
+        prev: previous_link(data, view, conn, number, size),
+        self: view.url_for_pagination(data, conn, %{size: size, page: number})
       }
     end
 
@@ -596,11 +597,13 @@ defmodule JSONAPI.SerializerTest do
     page = conn.assigns.jsonapi_query.page
     first = view.url_for_pagination(data, conn, %{page | "page" => 1})
     last = view.url_for_pagination(data, conn, %{page | "page" => 3})
+    self = view.url_for_pagination(data, conn, page)
 
     assert encoded[:links][:first] == first
     assert encoded[:links][:last] == last
     assert encoded[:links][:next] == last
     assert encoded[:links][:prev] == first
+    assert encoded[:links][:self] == self
   end
 
   test "serialize does not include pagination links if they are not defined" do


### PR DESCRIPTION
I was working with @kbaird when we came across the issue with #207.  This combines the version of `merge_base_links/4` previous to #189 and the implementation it introduced. This keeps all tests green while fixing our issue with `self` pagination links.