### PR TITLE
Add query parameters to the links

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -47,6 +47,8 @@ defmodule JSONAPI.Serializer do
     merge_links(encoded_data, data, view, conn, query_page, remove_links?(), options)
   end
 
+  def encode_data(view, nil, conn, query_includes, options), do: {[], nil}
+
   def encode_data(view, data, conn, query_includes, options) when is_list(data) do
     Enum.map_reduce(data, [], fn d, acc ->
       {to_include, encoded_data} = encode_data(view, d, conn, query_includes, options)

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -47,7 +47,7 @@ defmodule JSONAPI.Serializer do
     merge_links(encoded_data, data, view, conn, query_page, remove_links?(), options)
   end
 
-  def encode_data(view, nil, conn, query_includes, options), do: {[], nil}
+  def encode_data(_view, nil, _conn, _query_includes, _options), do: {[], nil}
 
   def encode_data(view, data, conn, query_includes, options) when is_list(data) do
     Enum.map_reduce(data, [], fn d, acc ->

--- a/lib/jsonapi/utils/list.ex
+++ b/lib/jsonapi/utils/list.ex
@@ -4,10 +4,6 @@ defmodule JSONAPI.Utils.List do
   @doc """
   Transforms a Map into a List of Tuples that can be converted into a query string via URI.encode_query/1
 
-  - if values are terms that implements the String.Chars protocol it returns [{key1, value1}, {key2, value2}]
-  - if any value is a list es. %{key1: ["a", "b"]} it returns [{key1[], "a"}, {key1[], "b"}]
-  - if any value is a map es. %{key1: %{key2: "c", key3: "d"}} it returns [{key1[key2], "c"}, {key1[key3], "d"}]
-
   ## Examples
 
       iex> to_list_of_query_string_components(%{"number" => 5})

--- a/lib/jsonapi/utils/list.ex
+++ b/lib/jsonapi/utils/list.ex
@@ -1,0 +1,50 @@
+defmodule JSONAPI.Utils.List do
+  @moduledoc """
+  Utility functions to build a list from a map in a different format than the one returned by Map.to_list/2
+  """
+
+  @doc """
+  Transform a map es. %{key1: value1, key2: value2} into a list of two element tuple.
+
+  - if values are terms that implements the String.Chars protocol it returns [{key1, value1}, {key2, value2}]
+  - if any value is a list es. %{key1: ["a", "b"]} it returns [{key1[], "a"}, {key1[], "b"}]
+  - if any value is a map es. %{key1: %{key2: "c", key3: "d"}} it returns [{key1[key2], "c"}, {key1[key3], "d"}]
+
+  ## Examples
+
+      iex> to_custom_list(%{"number" => 5})
+      [{"number", 5}]
+
+      iex> to_custom_list(%{color: "red"})
+      [{:color, "red"}]
+
+      iex> to_custom_list(%{"alphabet" => ["a", "b", "c"]})
+      [{"alphabet[]", "a"}, {"alphabet[]", "b"}, {"alphabet[]", "c"}]
+
+      iex> to_custom_list(%{"filters" => %{"age" => 18, "name" => "John"}})
+      [{"filters[age]", 18}, {"filters[name]", "John"}]
+
+  """
+  @spec to_custom_list(map()) :: list(tuple())
+  def to_custom_list(map) when is_map(map) do
+    Enum.flat_map(map, &do_to_custom_list/1)
+  end
+
+  defp do_to_custom_list({key, value}) when is_list(value) do
+    to_list_of_tuple(key, value)
+  end
+
+  defp do_to_custom_list({key, value}) when is_map(value) do
+    Enum.flat_map(value, fn {k, v} -> to_list_of_tuple("#{key}[#{k}]", v) end)
+  end
+
+  defp do_to_custom_list({key, value}), do: to_list_of_tuple(key, value)
+
+  defp to_list_of_tuple(key, value) when is_list(value) do
+    Enum.map(value, &{"#{key}[]", &1})
+  end
+
+  defp to_list_of_tuple(key, value) do
+    [{key, value}]
+  end
+end

--- a/lib/jsonapi/utils/list.ex
+++ b/lib/jsonapi/utils/list.ex
@@ -29,20 +29,20 @@ defmodule JSONAPI.Utils.List do
   end
 
   defp do_to_list_of_query_string_components({key, value}) when is_list(value) do
-    into_tuple_and_put_in_list(key, value)
+    to_list_of_two_elem_tuple(key, value)
   end
 
   defp do_to_list_of_query_string_components({key, value}) when is_map(value) do
-    Enum.flat_map(value, fn {k, v} -> into_tuple_and_put_in_list("#{key}[#{k}]", v) end)
+    Enum.flat_map(value, fn {k, v} -> to_list_of_two_elem_tuple("#{key}[#{k}]", v) end)
   end
 
-  defp do_to_list_of_query_string_components({key, value}), do: into_tuple_and_put_in_list(key, value)
+  defp do_to_list_of_query_string_components({key, value}), do: to_list_of_two_elem_tuple(key, value)
 
-  defp into_tuple_and_put_in_list(key, value) when is_list(value) do
+  defp to_list_of_two_elem_tuple(key, value) when is_list(value) do
     Enum.map(value, &{"#{key}[]", &1})
   end
 
-  defp into_tuple_and_put_in_list(key, value) do
+  defp to_list_of_two_elem_tuple(key, value) do
     [{key, value}]
   end
 end

--- a/lib/jsonapi/utils/list.ex
+++ b/lib/jsonapi/utils/list.ex
@@ -1,10 +1,8 @@
 defmodule JSONAPI.Utils.List do
-  @moduledoc """
-  Utility functions to build a list from a map in a different format than the one returned by Map.to_list/2
-  """
+  @moduledoc false
 
   @doc """
-  Transform a map es. %{key1: value1, key2: value2} into a list of two element tuple.
+  Transforms a Map into a List of Tuples that can be converted into a query string via URI.encode_query/1
 
   - if values are terms that implements the String.Chars protocol it returns [{key1, value1}, {key2, value2}]
   - if any value is a list es. %{key1: ["a", "b"]} it returns [{key1[], "a"}, {key1[], "b"}]
@@ -12,39 +10,39 @@ defmodule JSONAPI.Utils.List do
 
   ## Examples
 
-      iex> to_custom_list(%{"number" => 5})
+      iex> to_list_of_query_string_components(%{"number" => 5})
       [{"number", 5}]
 
-      iex> to_custom_list(%{color: "red"})
+      iex> to_list_of_query_string_components(%{color: "red"})
       [{:color, "red"}]
 
-      iex> to_custom_list(%{"alphabet" => ["a", "b", "c"]})
+      iex> to_list_of_query_string_components(%{"alphabet" => ["a", "b", "c"]})
       [{"alphabet[]", "a"}, {"alphabet[]", "b"}, {"alphabet[]", "c"}]
 
-      iex> to_custom_list(%{"filters" => %{"age" => 18, "name" => "John"}})
+      iex> to_list_of_query_string_components(%{"filters" => %{"age" => 18, "name" => "John"}})
       [{"filters[age]", 18}, {"filters[name]", "John"}]
 
   """
-  @spec to_custom_list(map()) :: list(tuple())
-  def to_custom_list(map) when is_map(map) do
-    Enum.flat_map(map, &do_to_custom_list/1)
+  @spec to_list_of_query_string_components(map()) :: list(tuple())
+  def to_list_of_query_string_components(map) when is_map(map) do
+    Enum.flat_map(map, &do_to_list_of_query_string_components/1)
   end
 
-  defp do_to_custom_list({key, value}) when is_list(value) do
-    to_list_of_tuple(key, value)
+  defp do_to_list_of_query_string_components({key, value}) when is_list(value) do
+    into_tuple_and_put_in_list(key, value)
   end
 
-  defp do_to_custom_list({key, value}) when is_map(value) do
-    Enum.flat_map(value, fn {k, v} -> to_list_of_tuple("#{key}[#{k}]", v) end)
+  defp do_to_list_of_query_string_components({key, value}) when is_map(value) do
+    Enum.flat_map(value, fn {k, v} -> into_tuple_and_put_in_list("#{key}[#{k}]", v) end)
   end
 
-  defp do_to_custom_list({key, value}), do: to_list_of_tuple(key, value)
+  defp do_to_list_of_query_string_components({key, value}), do: into_tuple_and_put_in_list(key, value)
 
-  defp to_list_of_tuple(key, value) when is_list(value) do
+  defp into_tuple_and_put_in_list(key, value) when is_list(value) do
     Enum.map(value, &{"#{key}[]", &1})
   end
 
-  defp to_list_of_tuple(key, value) do
+  defp into_tuple_and_put_in_list(key, value) do
     [{key, value}]
   end
 end

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -241,7 +241,7 @@ defmodule JSONAPI.View do
         format(key, value)
       end
 
-      defp build_query_params({key, %{} = value}) do
+      defp build_query_params({key, value}) when is_map(value) do
         Enum.flat_map(value, fn {k, v} -> format("#{key}[#{k}]", v) end)
       end
 

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -238,20 +238,20 @@ defmodule JSONAPI.View do
       end
 
       defp build_query_params({key, value} = kv) when is_list(value) do
-        format(key, value)
+        to_query_string_tuple(key, value)
       end
 
       defp build_query_params({key, value}) when is_map(value) do
-        Enum.flat_map(value, fn {k, v} -> format("#{key}[#{k}]", v) end)
+        Enum.flat_map(value, fn {k, v} -> to_query_string_tuple("#{key}[#{k}]", v) end)
       end
 
-      defp build_query_params({key, value}), do: format(key, value)
+      defp build_query_params({key, value}), do: to_query_string_tuple(key, value)
 
-      defp format(key, value) when is_list(value) do
+      defp to_query_string_tuple(key, value) when is_list(value) do
         Enum.map(value, & {"#{key}[]", &1})
       end
 
-      defp format(key, value) do
+      defp to_query_string_tuple(key, value) do
         [{key, value}]
       end
 

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -217,7 +217,7 @@ defmodule JSONAPI.View do
 
       def url_for(data, nil), do: "#{namespace()}/#{type()}/#{id(data)}"
 
-      def url_for(data, %Plug.Conn{} = conn) when is_list(data) do
+      def url_for(data, %Plug.Conn{} = conn) when is_list(data) or is_nil(data) do
         "#{scheme(conn)}://#{host(conn)}#{namespace()}/#{type()}"
       end
 
@@ -231,6 +231,7 @@ defmodule JSONAPI.View do
 
       def url_for_pagination(data, %{query_params: query_params} = conn, pagination_attrs) do
         query_params
+        |> Map.drop([:__struct__])
         |> Map.put("page", pagination_attrs)
         |> Enum.flat_map(&build_query_params/1)
         |> URI.encode_query()

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -120,7 +120,7 @@ defmodule JSONAPI.View do
     {paginator, _opts} = Keyword.pop(opts, :paginator)
 
     quote do
-      import JSONAPI.Utils.List, only: [to_custom_list: 1]
+      import JSONAPI.Utils.List, only: [to_list_of_query_string_components: 1]
       import JSONAPI.Serializer, only: [serialize: 5]
 
       @resource_type unquote(type)
@@ -233,7 +233,7 @@ defmodule JSONAPI.View do
       def url_for_pagination(data, %{query_params: query_params} = conn, pagination_attrs) do
         query_params
         |> Map.put("page", pagination_attrs)
-        |> to_custom_list()
+        |> to_list_of_query_string_components()
         |> URI.encode_query()
         |> prepare_url(data, conn)
       end

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -229,14 +229,19 @@ defmodule JSONAPI.View do
         "#{url_for(data, conn)}/relationships/#{rel_type}"
       end
 
-      def url_for_pagination(data, conn, pagination_attrs) do
-        pagination_attrs
-        |> Enum.reduce(%{}, fn {key, value}, acc ->
-          Map.put(acc, "page[#{key}]", value)
-        end)
+      def url_for_pagination(data, %{query_params: query_params} = conn, pagination_attrs) do
+        query_params
+        |> Map.put("page", pagination_attrs)
+        |> Enum.flat_map(&build_query_params/1)
         |> URI.encode_query()
         |> prepare_url(data, conn)
       end
+
+      defp build_query_params({key, %{} = value}) do
+        Enum.map(value, fn {k, v} -> {"#{key}[#{k}]", v} end)
+      end
+
+      defp build_query_params(data), do: [data]
 
       defp prepare_url("", data, conn), do: url_for(data, conn)
 

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -238,11 +238,23 @@ defmodule JSONAPI.View do
         |> prepare_url(data, conn)
       end
 
-      defp build_query_params({key, %{} = value}) do
-        Enum.map(value, fn {k, v} -> {"#{key}[#{k}]", v} end)
+      defp build_query_params({key, value} = kv) when is_list(value) do
+        format(key, value)
       end
 
-      defp build_query_params(data), do: [data]
+      defp build_query_params({key, %{} = value}) do
+        Enum.flat_map(value, fn {k, v} -> format("#{key}[#{k}]", v) end)
+      end
+
+      defp build_query_params({key, value}), do: format(key, value)
+
+      defp format(key, value) when is_list(value) do
+        Enum.map(value, & {"#{key}[]", &1})
+      end
+
+      defp format(key, value) do
+        [{key, value}]
+      end
 
       defp prepare_url("", data, conn), do: url_for(data, conn)
 

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -231,7 +231,6 @@ defmodule JSONAPI.View do
 
       def url_for_pagination(data, %{query_params: query_params} = conn, pagination_attrs) do
         query_params
-        |> Map.drop([:__struct__])
         |> Map.put("page", pagination_attrs)
         |> Enum.flat_map(&build_query_params/1)
         |> URI.encode_query()

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -641,7 +641,7 @@ defmodule JSONAPI.SerializerTest do
   end
 
   test "serialize returns a null data if it receives a null data" do
-      assert %{
+    assert %{
              data: data,
              links: links
            } = Serializer.serialize(ExpensiveResourceView, nil, nil)

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -142,6 +142,8 @@ defmodule JSONAPI.SerializerTest do
 
     def type, do: "expensive-resource"
 
+    def links(nil, _conn), do: %{}
+
     def links(data, _conn) do
       %{
         queue: "/expensive-resource/queue/#{data.id}",
@@ -636,5 +638,15 @@ defmodule JSONAPI.SerializerTest do
     }
 
     assert expected_links == links
+  end
+
+  test "serialize returns a null data if it receives a null data" do
+      assert %{
+             data: data,
+             links: links
+           } = Serializer.serialize(ExpensiveResourceView, nil, nil)
+
+    assert nil == data
+    assert %{self: "/expensive-resource"} == links
   end
 end

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -590,6 +590,7 @@ defmodule JSONAPI.SerializerTest do
       :get
       |> Plug.Test.conn("/mytype?page[page]=2&page[size]=1")
       |> QueryParser.call(%Config{view: view, opts: []})
+      |> Plug.Conn.fetch_query_params()
 
     encoded =
       Serializer.serialize(PaginatedPostView, data, conn, nil, total_pages: 3, total_items: 3)

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -150,10 +150,10 @@ defmodule JSONAPI.ViewTest do
 
     assert PostView.url_for_pagination(nil, conn, %{}) == "http://www.example.com/api/posts"
 
-    assert PostView.url_for_pagination(nil, conn, %{number: 1, size: 10}) ==
+    assert PostView.url_for_pagination(nil, conn, %{"number" => 1, "size" => 10}) ==
              "http://www.example.com/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
 
-    conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, :comments, [5, 2]))
+    conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, "comments", [5, 2]))
 
     assert PostView.url_for_pagination(nil, conn_with_query_params, %{}) ==
              "http://www.example.com/api/posts?comments%5B%5D=5&comments%5B%5D=2"

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -153,10 +153,10 @@ defmodule JSONAPI.ViewTest do
     assert PostView.url_for_pagination(nil, conn, %{number: 1, size: 10}) ==
              "http://www.example.com/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
 
-    conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, :number, 5))
+    conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, :comments, [5, 2]))
 
     assert PostView.url_for_pagination(nil, conn_with_query_params, %{}) ==
-             "http://www.example.com/api/posts?number=5"
+             "http://www.example.com/api/posts?comments%5B%5D=5&comments%5B%5D=2"
   end
 
   test "render/2 is defined when 'Phoenix' is loaded" do

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -158,7 +158,8 @@ defmodule JSONAPI.ViewTest do
     end
 
     test "with query parameters", %{conn: conn} do
-      conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, "comments", [5, 2]))
+      conn_with_query_params =
+        Kernel.update_in(conn.query_params, &Map.put(&1, "comments", [5, 2]))
 
       assert PostView.url_for_pagination(nil, conn_with_query_params, %{number: 1, size: 10}) ==
                "http://www.example.com/api/posts?comments%5B%5D=5&comments%5B%5D=2&page%5Bnumber%5D=1&page%5Bsize%5D=10"

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -146,10 +146,17 @@ defmodule JSONAPI.ViewTest do
   end
 
   test "url_for_pagination/3" do
-    assert PostView.url_for_pagination(nil, nil, %{}) == "/api/posts"
+    conn = Plug.Conn.fetch_query_params(%Plug.Conn{})
 
-    assert PostView.url_for_pagination(nil, nil, %{number: 1, size: 10}) ==
-             "/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+    assert PostView.url_for_pagination(nil, conn, %{}) == "http://www.example.com/api/posts"
+
+    assert PostView.url_for_pagination(nil, conn, %{number: 1, size: 10}) ==
+             "http://www.example.com/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+
+    conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, :number, 5))
+
+    assert PostView.url_for_pagination(nil, conn_with_query_params, %{}) ==
+             "http://www.example.com/api/posts?number=5"
   end
 
   test "render/2 is defined when 'Phoenix' is loaded" do

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -145,18 +145,27 @@ defmodule JSONAPI.ViewTest do
     end
   end
 
-  test "url_for_pagination/3" do
-    conn = Plug.Conn.fetch_query_params(%Plug.Conn{})
+  describe "url_for_pagination/3" do
+    setup do
+      {:ok, conn: Plug.Conn.fetch_query_params(%Plug.Conn{})}
+    end
 
-    assert PostView.url_for_pagination(nil, conn, %{}) == "http://www.example.com/api/posts"
+    test "with pagination information", %{conn: conn} do
+      assert PostView.url_for_pagination(nil, conn, %{}) == "http://www.example.com/api/posts"
 
-    assert PostView.url_for_pagination(nil, conn, %{"number" => 1, "size" => 10}) ==
-             "http://www.example.com/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+      assert PostView.url_for_pagination(nil, conn, %{number: 1, size: 10}) ==
+               "http://www.example.com/api/posts?page%5Bnumber%5D=1&page%5Bsize%5D=10"
+    end
 
-    conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, "comments", [5, 2]))
+    test "with query parameters", %{conn: conn} do
+      conn_with_query_params = Kernel.update_in(conn.query_params, &Map.put(&1, "comments", [5, 2]))
 
-    assert PostView.url_for_pagination(nil, conn_with_query_params, %{}) ==
-             "http://www.example.com/api/posts?comments%5B%5D=5&comments%5B%5D=2"
+      assert PostView.url_for_pagination(nil, conn_with_query_params, %{number: 1, size: 10}) ==
+               "http://www.example.com/api/posts?comments%5B%5D=5&comments%5B%5D=2&page%5Bnumber%5D=1&page%5Bsize%5D=10"
+
+      assert PostView.url_for_pagination(nil, conn_with_query_params, %{}) ==
+               "http://www.example.com/api/posts?comments%5B%5D=5&comments%5B%5D=2"
+    end
   end
 
   test "render/2 is defined when 'Phoenix' is loaded" do

--- a/test/utils/list_test.exs
+++ b/test/utils/list_test.exs
@@ -1,0 +1,9 @@
+defmodule JSONAPI.Utils.ListTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  import JSONAPI.Utils.List
+
+  doctest JSONAPI.Utils.List
+end


### PR DESCRIPTION
Query parameters are missing from the generated payload and pagination links which only include pagination information (page offset and size).