### PR TITLE
Return correct error for patch calls missing data[type]

### DIFF
--- a/lib/jsonapi/plugs/format_required.ex
+++ b/lib/jsonapi/plugs/format_required.ex
@@ -25,8 +25,12 @@ defmodule JSONAPI.FormatRequired do
 
   def call(%{params: %{"data" => %{"type" => _, "id" => _}}} = conn, _), do: conn
 
-  def call(%{method: "PATCH", params: %{"data" => %{"attributes" => _}}} = conn, _) do
+  def call(%{method: "PATCH", params: %{"data" => %{"attributes" => _, "type" => _}}} = conn, _) do
     send_error(conn, missing_data_id_param())
+  end
+
+  def call(%{method: "PATCH", params: %{"data" => %{"attributes" => _, "id" => _}}} = conn, _) do
+    send_error(conn, missing_data_type_param())
   end
 
   def call(%{params: %{"data" => %{"attributes" => _}}} = conn, _),

--- a/test/jsonapi/plugs/format_required_test.exs
+++ b/test/jsonapi/plugs/format_required_test.exs
@@ -78,6 +78,23 @@ defmodule JSONAPI.FormatRequiredTest do
            } = error
   end
 
+  test "halts and returns an error for missing type in data param on a patch" do
+    conn =
+      :patch
+      |> conn("/example", Jason.encode!(%{data: %{attributes: %{}, id: "something"}}))
+      |> call_plug
+
+    assert conn.halted
+    assert 400 == conn.status
+
+    %{"errors" => [error]} = Jason.decode!(conn.resp_body)
+
+    assert %{
+             "source" => %{"pointer" => "/data/type"},
+             "title" => "Missing type in data parameter"
+           } = error
+  end
+
   test "does not halt if type and id members are present on a patch" do
     conn =
       :patch


### PR DESCRIPTION
With a PATCH call that is missing the `type`, we were receiving an error that the `id` was missing even when it was present. This PR updates the `FormatRequired` plug to return the correct error and adds a test for it. Examples given below.

When sending this payload
```elixir
{
  "data" => {
    "id" => 12345,
    "attributes" => {
      "stuff" => "things"
    }
  }
}
```
this error was being returned
```elixir
{
  "errors" => [
    {
      "detail" => "Check out http://jsonapi.org/format/#crud for more info.",
      "source" => {
        "pointer" => "/data/id"
      },
      "status" => "400",
      "title" => "Missing id in data parameter"
    }
  ]
}
```
we would expect to receive an error like this
```elixir
{
  "errors" => [
    {
      "detail" => "Check out http://jsonapi.org/format/#crud for more info.",
      "source" => {
        "pointer" => "/data/type"
      },
      "status" => "400",
      "title" => "Missing type in data parameter"
    }
  ]
}
```