### PR TITLE
Improve documentation around UnderscoreParameters deserializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please see its documentation for details.
 
 JSONAPI has recommended in the past the use of dashes (`-`) in place of underscore (`_`) as a
 word separator for document member keys. However, as of [JSON API Spec (v1.1)](https://jsonapi.org/format/1.1/), it is now recommended that member names
-are camelCased. This library provides various configuration options for maximum flexibility.
+are camelCased. This library provides various configuration options for maximum flexibility including serializing outgoing parameters and deserializing incoming paramenters.
 
 Transforming fields requires two steps:
 
@@ -123,8 +123,8 @@ Transforming fields requires two steps:
 
    ```elixir
    pipeline :api do
-     plug(JSONAPI.EnsureSpec)
-     plug(JSONAPI.UnderscoreParameters)
+     plug JSONAPI.EnsureSpec
+     plug JSONAPI.UnderscoreParameters
    end
    ```
 

--- a/lib/jsonapi/plugs/underscore_parameters.ex
+++ b/lib/jsonapi/plugs/underscore_parameters.ex
@@ -1,7 +1,8 @@
 defmodule JSONAPI.UnderscoreParameters do
   @moduledoc """
-  Takes dasherized JSON:API params and turns them into underscored params. Add
-  this to your API's pipeline to aid in dealing with incoming parameters.
+  Takes dasherized JSON:API params and deserializes them to underscored params. Add
+  this to your API's pipeline to aid in dealing with incoming parameters such as query
+  params or data.
 
   Note that this Plug will only underscore parameters when the request's content
   type is for a JSON:API request (i.e. "application/vnd.api+json"). All other
@@ -9,7 +10,25 @@ defmodule JSONAPI.UnderscoreParameters do
 
   ## Example
 
-  Given a request like:
+  %{
+    "data" => %{
+      "attributes" => %{
+        "foo-bar" => true
+      }
+    }
+  }
+
+  are transformed to:
+
+  %{
+    "data" => %{
+      "attributes" => %{
+        "foo_bar" => true
+      }
+    }
+  }
+
+  Moreover, with a GET request like:
 
       GET /example?filters[dog-breed]=Corgi
 
@@ -26,8 +45,8 @@ defmodule JSONAPI.UnderscoreParameters do
       # e.g. a Phoenix app
 
       pipeline :api do
-        plug(JSONAPI.EnforceSpec)
-        plug(JSONAPI.UnderscoreParameters)
+        plug JSONAPI.EnforceSpec
+        plug JSONAPI.UnderscoreParameters
       end
   """
 


### PR DESCRIPTION
@jeregrine Let me know what you think about these improvements.  They are super minor.  

However, one util that I often use during deserialization (in combination with casing params) is flattening params for changeset casting.  Do you think it is worthwhile to provide a plug for this?

```ex
   %{
      "id" => "1",
      "data" => %{
        "attributes" => %{"foo" => "bar", "baz" => "bat"},
        "type" => "user"
      }
    }
```

converted to


```ex
   %{
      "baz" => "bat",
      "foo" => "bar",
      "id" => "1",
      "type" => "user"
    }
```

ref #222