### PR TITLE
Query parameters in self url

### DIFF
--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -161,9 +161,15 @@ defmodule JSONAPI.Serializer do
     merge_related_links(data, info, remove_links?())
   end
 
-  defp merge_base_links(%{links: links} = doc, data, view, conn) do
+  defp merge_base_links(%{links: links} = doc, data, view, conn, page) do
+    self = case page do
+      nil -> view.url_for(data, conn)
+      _ ->
+        view.url_for_pagination(data, conn, page)
+    end
+
     view_links =
-      %{self: view.url_for(data, conn)}
+      %{self: self}
       |> Map.merge(view.links(data, conn))
       |> Map.merge(links)
 
@@ -173,13 +179,13 @@ defmodule JSONAPI.Serializer do
   defp merge_links(doc, data, view, conn, nil, false, _options) do
     doc
     |> Map.merge(%{links: %{}})
-    |> merge_base_links(data, view, conn)
+    |> merge_base_links(data, view, conn, nil)
   end
 
   defp merge_links(doc, data, view, conn, page, false, options) do
     doc
     |> Map.merge(%{links: view.pagination_links(data, conn, page, options)})
-    |> merge_base_links(data, view, conn)
+    |> merge_base_links(data, view, conn, page)
   end
 
   defp merge_links(doc, _data, _view, _conn, _page, _remove_links, _options), do: doc

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -161,31 +161,26 @@ defmodule JSONAPI.Serializer do
     merge_related_links(data, info, remove_links?())
   end
 
-  defp merge_base_links(%{links: links} = doc, data, view, conn, page) do
-    self = case page do
-      nil -> view.url_for(data, conn)
-      _ ->
-        view.url_for_pagination(data, conn, page)
-    end
-
-    view_links =
-      %{self: self}
-      |> Map.merge(view.links(data, conn))
-      |> Map.merge(links)
-
+  defp merge_base_links(%{links: links} = doc, data, view, conn) do
+    view_links = Map.merge(view.links(data, conn), links)
     Map.merge(doc, %{links: view_links})
   end
 
   defp merge_links(doc, data, view, conn, nil, false, _options) do
     doc
-    |> Map.merge(%{links: %{}})
-    |> merge_base_links(data, view, conn, nil)
+    |> Map.merge(%{links: %{self: view.url_for(data, conn)}})
+    |> merge_base_links(data, view, conn)
   end
 
   defp merge_links(doc, data, view, conn, page, false, options) do
+    links =
+      Map.merge(view.pagination_links(data, conn, page, options), %{
+        self: view.url_for_pagination(data, conn, page)
+      })
+
     doc
-    |> Map.merge(%{links: view.pagination_links(data, conn, page, options)})
-    |> merge_base_links(data, view, conn, page)
+    |> Map.merge(%{links: links})
+    |> merge_base_links(data, view, conn)
   end
 
   defp merge_links(doc, _data, _view, _conn, _page, _remove_links, _options), do: doc

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -166,13 +166,7 @@ defmodule JSONAPI.Serializer do
     Map.merge(doc, %{links: view_links})
   end
 
-  defp merge_links(doc, data, view, conn, nil, false, _options) do
-    doc
-    |> Map.merge(%{links: %{self: view.url_for(data, conn)}})
-    |> merge_base_links(data, view, conn)
-  end
-
-  defp merge_links(doc, data, view, conn, page, false, options) do
+  defp merge_links(doc, data, view, conn, page, false, options) when is_list(data) do
     links =
       Map.merge(view.pagination_links(data, conn, page, options), %{
         self: view.url_for_pagination(data, conn, page)
@@ -180,6 +174,12 @@ defmodule JSONAPI.Serializer do
 
     doc
     |> Map.merge(%{links: links})
+    |> merge_base_links(data, view, conn)
+  end
+
+  defp merge_links(doc, data, view, conn, _page, false, _options) do
+    doc
+    |> Map.merge(%{links: %{self: view.url_for(data, conn)}})
     |> merge_base_links(data, view, conn)
   end
 

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -230,12 +230,17 @@ defmodule JSONAPI.View do
         "#{url_for(data, conn)}/relationships/#{rel_type}"
       end
 
-      def url_for_pagination(data, %{query_params: query_params} = conn, pagination_attrs) do
+      def url_for_pagination(data, %{query_params: query_params} = conn, nil = _pagination_attrs) do
         query_params
-        |> Map.put("page", pagination_attrs)
         |> to_list_of_query_string_components()
         |> URI.encode_query()
         |> prepare_url(data, conn)
+      end
+
+      def url_for_pagination(data, %{query_params: query_params} = conn, pagination_attrs) do
+        query_params = Map.put(query_params, "page", pagination_attrs)
+
+        url_for_pagination(data, %{conn | query_params: query_params}, nil)
       end
 
       defp prepare_url("", data, conn), do: url_for(data, conn)

--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -119,6 +119,7 @@ defmodule JSONAPI.View do
     {namespace, opts} = Keyword.pop(opts, :namespace)
     {paginator, _opts} = Keyword.pop(opts, :paginator)
 
+    # credo:disable-for-next-line Credo.Check.Refactor.LongQuoteBlocks
     quote do
       import JSONAPI.Utils.List, only: [to_list_of_query_string_components: 1]
       import JSONAPI.Serializer, only: [serialize: 5]

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -335,13 +335,15 @@ defmodule JSONAPI.SerializerTest do
       ]
     }
 
-    conn = %Plug.Conn{
-      assigns: %{
-        jsonapi_query: %Config{
-          include: [best_comments: :user]
+    conn =
+      %Plug.Conn{
+        assigns: %{
+          jsonapi_query: %Config{
+            include: [best_comments: :user]
+          }
         }
       }
-    }
+      |> Plug.Conn.fetch_query_params()
 
     encoded = Serializer.serialize(PostView, data, conn)
 
@@ -360,13 +362,15 @@ defmodule JSONAPI.SerializerTest do
       company: %{id: 2, name: "acme"}
     }
 
-    conn = %Plug.Conn{
-      assigns: %{
-        jsonapi_query: %Config{
-          include: [:company]
+    conn =
+      %Plug.Conn{
+        assigns: %{
+          jsonapi_query: %Config{
+            include: [:company]
+          }
         }
       }
-    }
+      |> Plug.Conn.fetch_query_params()
 
     encoded = Serializer.serialize(UserView, data, conn)
 
@@ -385,13 +389,15 @@ defmodule JSONAPI.SerializerTest do
       company: %{id: 2, name: "acme", industry: %{id: 4, name: "stuff"}}
     }
 
-    conn = %Plug.Conn{
-      assigns: %{
-        jsonapi_query: %Config{
-          include: [company: :industry]
+    conn =
+      %Plug.Conn{
+        assigns: %{
+          jsonapi_query: %Config{
+            include: [company: :industry]
+          }
         }
       }
-    }
+      |> Plug.Conn.fetch_query_params()
 
     encoded = Serializer.serialize(UserView, data, conn)
 
@@ -421,13 +427,15 @@ defmodule JSONAPI.SerializerTest do
       }
     }
 
-    conn = %Plug.Conn{
-      assigns: %{
-        jsonapi_query: %Config{
-          include: [company: [industry: :tags]]
+    conn =
+      %Plug.Conn{
+        assigns: %{
+          jsonapi_query: %Config{
+            include: [company: [industry: :tags]]
+          }
         }
       }
-    }
+      |> Plug.Conn.fetch_query_params()
 
     encoded = Serializer.serialize(UserView, data, conn)
 

--- a/test/jsonapi/serializer_test.exs
+++ b/test/jsonapi/serializer_test.exs
@@ -230,7 +230,9 @@ defmodule JSONAPI.SerializerTest do
 
     data_list = [data, data, data]
 
-    encoded = Serializer.serialize(PostView, data_list, nil)
+    conn = Plug.Conn.fetch_query_params(%Plug.Conn{})
+
+    encoded = Serializer.serialize(PostView, data_list, conn)
 
     assert Enum.count(encoded[:data]) == 3
 
@@ -242,7 +244,7 @@ defmodule JSONAPI.SerializerTest do
       assert attributes[:text] == data[:text]
       assert attributes[:body] == data[:body]
 
-      assert enc[:links][:self] == PostView.url_for(data, nil)
+      assert enc[:links][:self] == PostView.url_for(data, conn)
       assert map_size(enc[:relationships]) == 2
     end)
 
@@ -318,9 +320,9 @@ defmodule JSONAPI.SerializerTest do
   end
 
   test "serialize handles a relationship self link on an index request" do
-    encoded = Serializer.serialize(PostView, [], nil)
+    encoded = Serializer.serialize(PostView, [], Plug.Conn.fetch_query_params(%Plug.Conn{}))
 
-    assert encoded[:links][:self] == "/mytype"
+    assert encoded[:links][:self] == "http://www.example.com/mytype"
   end
 
   test "serialize handles including from the query" do
@@ -620,7 +622,7 @@ defmodule JSONAPI.SerializerTest do
   test "serialize does not include pagination links if they are not defined" do
     data = [%{id: 1}]
 
-    encoded = Serializer.serialize(UserView, data, nil)
+    encoded = Serializer.serialize(UserView, data, Plug.Conn.fetch_query_params(%Plug.Conn{}))
     refute encoded[:links][:first]
     refute encoded[:links][:last]
     refute encoded[:links][:next]

--- a/test/jsonapi/view_test.exs
+++ b/test/jsonapi/view_test.exs
@@ -190,7 +190,12 @@ defmodule JSONAPI.ViewTest do
   end
 
   test "index renders with data, conn" do
-    data = CommentView.render("index.json", %{data: [%{id: 1, body: "hi"}], conn: %Plug.Conn{}})
+    data =
+      CommentView.render("index.json", %{
+        data: [%{id: 1, body: "hi"}],
+        conn: Plug.Conn.fetch_query_params(%Plug.Conn{})
+      })
+
     data = Enum.at(data.data, 0)
     assert data.attributes.body == "hi"
   end
@@ -199,7 +204,7 @@ defmodule JSONAPI.ViewTest do
     data =
       CommentView.render("index.json", %{
         data: [%{id: 1, body: "hi"}],
-        conn: %Plug.Conn{},
+        conn: Plug.Conn.fetch_query_params(%Plug.Conn{}),
         meta: %{total_pages: 100}
       })
 

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -106,6 +106,7 @@ defmodule JSONAPITest do
       |> conn("/posts")
       |> Plug.Conn.assign(:data, [@default_data])
       |> Plug.Conn.assign(:meta, %{total_pages: 1})
+      |> Plug.Conn.fetch_query_params()
       |> MyPostPlug.call([])
 
     json = conn.resp_body |> Jason.decode!()
@@ -296,6 +297,7 @@ defmodule JSONAPITest do
         :get
         |> conn("/posts?include=other_user.company&fields[mytype]=text,excerpt,first_character")
         |> Plug.Conn.assign(:data, [@default_data])
+        |> Plug.Conn.fetch_query_params()
         |> MyPostPlug.call([])
 
       assert %{
@@ -328,6 +330,7 @@ defmodule JSONAPITest do
         :get
         |> conn("/posts?include=other_user.company&fields[mytype]=text,first-character")
         |> Plug.Conn.assign(:data, [@default_data])
+        |> Plug.Conn.fetch_query_params()
         |> MyPostPlug.call([])
 
       assert %{
@@ -349,6 +352,7 @@ defmodule JSONAPITest do
       |> conn("/posts")
       |> Plug.Conn.assign(:data, [@default_data])
       |> Plug.Conn.assign(:meta, nil)
+      |> Plug.Conn.fetch_query_params()
       |> MyPostPlug.call([])
 
     json = conn.resp_body |> Jason.decode!()
@@ -361,6 +365,7 @@ defmodule JSONAPITest do
       :get
       |> conn("/posts")
       |> Plug.Conn.assign(:data, [@default_data])
+      |> Plug.Conn.fetch_query_params()
       |> MyPostPlug.call([])
 
     json = conn.resp_body |> Jason.decode!()


### PR DESCRIPTION
The self url includes query parameters.

For example, the self url for `http://localhost/users?page[page]=2` is the url itself, instead of `http://localhost/users`