### PR TITLE
Prepare for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.3.0 (2020-03-21)
+
+### Added
+
+- [Add Deserializer Plug](https://github.com/jeregrine/jsonapi/pull/222)
+
+### Changed
+
+- [Continuous](https://github.com/jeregrine/jsonapi/pull/226) [Integration](https://github.com/jeregrine/jsonapi/pull/227)
+  with Github actions.
+- ["self" URL can include query parameters](https://github.com/jeregrine/jsonapi/pull/224)
+
+### Contributors
+
+A healthy Covid-19 safe foot-tap to: @CostantiniMatteo, @lucacorti, @snewcomer, and @jherdman
+
 ## 1.2.3 (2020-01-28)
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSONAPI.Mixfile do
   def project do
     [
       app: :jsonapi,
-      version: "1.2.3",
+      version: "1.3.0",
       package: package(),
       compilers: compilers(Mix.env()),
       description: description(),
@@ -58,7 +58,13 @@ defmodule JSONAPI.Mixfile do
 
   defp package do
     [
-      maintainers: ["Jason Stiebs", "Mitchell Henke", "Jake Robers", "Sean Callan"],
+      maintainers: [
+        "Jason Stiebs",
+        "Mitchell Henke",
+        "Jake Robers",
+        "Sean Callan",
+        "James Herdman"
+      ],
       licenses: ["MIT"],
       links: %{github: "https://github.com/jeregrine/jsonapi", docs: "http://hexdocs.pm/jsonapi/"}
     ]


### PR DESCRIPTION
Given the low traffic on this project it's probably wise to cut a release with the new Deserializer plug feature.