### PR TITLE
Convert include fields in snake_case

### DIFF
--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -191,6 +191,7 @@ defmodule JSONAPI.QueryParser do
 
   def handle_include(str, config) when is_binary(str) do
     valid_includes = get_base_relationships(config.view)
+
     includes =
       str
       |> String.split(",")

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -191,7 +191,10 @@ defmodule JSONAPI.QueryParser do
 
   def handle_include(str, config) when is_binary(str) do
     valid_includes = get_base_relationships(config.view)
-    includes = String.split(str, ",")
+    includes =
+      str
+      |> String.split(",")
+      |> Enum.map(&underscore/1)
 
     Enum.reduce(includes, [], fn inc, acc ->
       if inc =~ ~r/\w+\.\w+/ do

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -82,6 +82,7 @@ defmodule JSONAPI.QueryParserTest do
     assert parse_include(config, "comments,author").include == [:comments, :author]
     assert parse_include(config, "comments.user").include == [comments: :user]
     assert parse_include(config, "best_friends").include == [:best_friends]
+    assert parse_include(config, "author.top-posts").include == [author: :top_posts]
   end
 
   test "parse_include/2 errors with invalid includes" do
@@ -99,11 +100,7 @@ defmodule JSONAPI.QueryParserTest do
       parse_include(config, "comments.author.user")
     end
 
-    assert_raise InvalidQuery, "invalid include, author.top-posts for type mytype", fn ->
-      assert parse_include(config, "author.top-posts")
-    end
-
-    assert_raise InvalidQuery, "invalid include, fake-rel for type mytype", fn ->
+    assert_raise InvalidQuery, "invalid include, fake_rel for type mytype", fn ->
       assert parse_include(config, "fake-rel")
     end
   end


### PR DESCRIPTION
Up to now, included resources names need to be passed using snake case as they will not be underscored by `QueryParser`, forcing you to include resource using the underscored name (e.g. `include=car_retailer` instead of `include=car-retailer`)

Other parameters such as fields and filter are underscored.
This PR underscores `include` values as well.