### PR TITLE
Fix failing test

### DIFF
--- a/test/jsonapi/plugs/underscore_parameters_test.exs
+++ b/test/jsonapi/plugs/underscore_parameters_test.exs
@@ -33,7 +33,7 @@ defmodule JSONAPI.UnderscoreParametersTest do
                    "first_name" => "John",
                    "last_name" => "Cleese",
                    "stats" => %{
-                     "age" => 45,
+                     "age" => "45",
                      "dog_name" => "Pedro"
                    }
                  }


### PR DESCRIPTION
Conn converts param values to string, so assert should expect stringified values.