### PR TITLE
loosen requirements on relations to allow non-ecto relations to be serialized as relationships.

### DIFF
--- a/lib/jsonapi/ecto.ex
+++ b/lib/jsonapi/ecto.ex
@@ -12,6 +12,7 @@ defmodule JSONAPI.Ecto do
   def assoc_loaded?(association) do
     case association do
       %{__struct__: Ecto.Association.NotLoaded} -> false
+      nil -> false
       _ -> true
     end
   end

--- a/lib/jsonapi/serializer.ex
+++ b/lib/jsonapi/serializer.ex
@@ -80,7 +80,7 @@ defmodule JSONAPI.Serializer do
   @spec encode_relationships(Plug.Conn.t(), serialized_doc(), tuple(), list()) :: tuple()
   def encode_relationships(conn, doc, {view, data, _, _} = view_info, options) do
     view.relationships()
-    |> Enum.filter(&data_loaded?(Map.get(data, elem(&1, 0))))
+    |> Enum.filter(&assoc_loaded?(Map.get(data, elem(&1, 0))))
     |> Enum.map_reduce(doc, &build_relationships(conn, view_info, &1, &2, options))
   end
 


### PR DESCRIPTION
This very small PR might be difficult to motivate on its own, but I will be submitting a couple more for consideration & discussion that depend on this change so I will get this out there first.

### At face value
Instead of avoiding building relationships any time no data is loaded (defined by `data_loaded?/1` as being a list or map and as not being `Ecto.Association.NotLoaded`), we now avoid building relationships only when the association is either `nil` or `Ecto.Association.NotLoaded`. In other words, allow for single-non-`nil` values to be processed as relationships.

### A bit deeper
Actual inclusion of a related resource is still guarded on line 117 by a call to the stricter `data_loaded?/1` function, so we don't change behavior of included relations. Because we check for non-`nil` in the changes to the `assoc_loaded?/1` function, we also retain the current behavior that `nil` relationships are not serialized at all.

However, because we allow non-`nil` single-values to be serialized (as relationships,  but not as included resources), we get the following:

A `JSONAPI.View` can be written such that its `id` function accepts a single-value instead of a map or schema struct and any arbitrary field on a schema can be represented as a relationship at the API layer.

This plays out as follows
```elixir
defmodule RemoteInventoryRelationView do
   use JSONAPI.View, type: "remote_inventory"

   def id(wsid) do
     wsid
   end
 end

defmodule WidgetView do
   use JSONAPI.View, type: "widget"

   def fields do
     [:created_at, :deleted_at]
   end

   def relationships do
     [
       in_house_components: ComponentView,
       remote_inventory_wisid: RemoteInventoryRelationView
     ]
   end
end
```

In this hypothetical example, a `remote_inventory` resource cannot be retrieved or included by this server, but there is a known third party API that can be used by an API client to look these remote inventories up.