### PR TITLE
Fix/string expand fields on leaves

### DIFF
--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -168,6 +168,9 @@ defmodule JSONAPI.Utils.String do
       iex> expand_fields(%{"attributes" => %{"corgiName" => ["Wardel"]}}, &underscore/1)
       %{"attributes" => %{"corgi_name" => ["Wardel"]}}
 
+      iex> expand_fields(%{"attributes" => %{"someField" => ["SomeValue", %{"nestedField" => "Value"}]}}, &underscore/1)
+      %{"attributes" => %{"some_field" => ["SomeValue", %{"nested_field" => "Value"}]}}
+
       iex> expand_fields([%{"fooBar" => "a"}, %{"fooBar" => "b"}], &underscore/1)
       [%{"foo_bar" => "a"}, %{"foo_bar" => "b"}]
 

--- a/lib/jsonapi/utils/string.ex
+++ b/lib/jsonapi/utils/string.ex
@@ -200,7 +200,6 @@ defmodule JSONAPI.Utils.String do
     {fun.(key), expand_fields(value, fun)}
   end
 
-  @spec expand_fields(tuple, function) :: tuple
   def expand_fields({key, value}, fun) when is_list(value) do
     {fun.(key), maybe_expand_fields(value, fun)}
   end


### PR DESCRIPTION
Hi guys! I'm opening this PR this fix what I think it's a bug.

When calling `JSONAPI.Utils.String.expand_fields`, the current behaviour is to always apply the transformation function to every element of a list. However, when the list is the value of a map, such strings are actual values and should be left as-is.

For example:
```
> expand_fields(%{"attributes" => %{"corgiName" => ["Wardel"]}}, &underscore/1)
%{"attributes" => %{"corgi_name" => ["wardel"]}}
```

Here `Wardel` is not a field which should be recased, but an actual value that should not change.

If the current implementation is expected behaviour, feel free to close this PR.

Thanks!