### PR TITLE
Fix compilation warning on Elixir 1.11.4

### DIFF
--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -250,7 +250,7 @@ defmodule JSONAPI.QueryParser do
 
   @spec get_view_for_type(module(), String.t()) :: module() | no_return()
   def get_view_for_type(view, type) do
-    case Enum.find(view.relationships, fn relationship ->
+    case Enum.find(view.relationships(), fn relationship ->
            is_field_valid_for_relationship(relationship, type)
          end) do
       {_, view} -> view


### PR DESCRIPTION
Missing parentheses calling `JSONAPI.View.relationships/0` in `JSONAPI.QueryParser.get_view_for_type/2` caused the compiler to warn about incompatible use of types (map and atom) for the variable `view`.