### PR TITLE
Modernize runtime dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: mix
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 999

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         otp: [24, 23, 22, 21]
         exclude:
           - {otp: '21', elixir: '1.12'}
+          - {otp: '24', elixir: '1.9'}
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
         elixir: ['1.12', '1.11', '1.10', '1.9']
         # All of the above can use this version. For details see: https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
         otp: [24, 23, 22, 21]
-
+        exclude:
+          - {otp: '21', elixir: '1.12'}
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:
       matrix:
-        elixir: ['1.10', '1.9', '1.8', '1.7']
+        elixir: ['1.12', '1.11', '1.10', '1.9']
         # All of the above can use this version. For details see: https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
-        otp: [22, 21]
+        otp: [24, 23, 22, 21]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,9 +33,9 @@ jobs:
     name: Linting
     strategy:
       matrix:
-        elixir: ['1.10']
+        elixir: ['1.12']
         # All of the above can use this version. For details see: https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
-        otp: [22, 21]
+        otp: [24]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule JSONAPI.Mixfile do
       package: package(),
       compilers: compilers(Mix.env()),
       description: description(),
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This moves support to the last 4 major OTP versions and minor Elixir versions and excludes a few incompatible combinations as per https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp

OTP 20 is almost 4 years old now and Elixir 1.8 is 2 years old and there is little reason to stick with old Elixir releases as they are always backwards compatible and trivial to upgrade.

Also, I've added dependabot configuration to simplify tracking of dependencies.
