### PR TITLE
Delegate path generation

### DIFF
--- a/lib/jsonapi/view.ex
+++ b/lib/jsonapi/view.ex
@@ -217,20 +217,27 @@ defmodule JSONAPI.View do
       def index(models, conn, _params, meta \\ nil, options \\ []),
         do: serialize(__MODULE__, models, conn, meta, options)
 
-      def path_for(data) when is_nil(data) or is_list(data),
-        do: URI.to_string(%URI{path: path() || type()})
+      def path_for(_data), do: path() || type()
 
-      def path_for(data),
-        do: URI.to_string(%URI{path: Enum.join([path() || type(), id(data)], "/")})
+      def url_for(data, nil = _conn) when is_nil(data) or is_list(data),
+        do: URI.to_string(%URI{path: Enum.join([namespace(), path_for(data)], "/")})
 
       def url_for(data, nil = _conn),
-        do: URI.to_string(%URI{path: Enum.join([namespace(), path_for(data)], "/")})
+        do: URI.to_string(%URI{path: Enum.join([namespace(), path_for(data), id(data)], "/")})
+
+      def url_for(data, %Plug.Conn{} = conn) when is_nil(data) or is_list(data) do
+        URI.to_string(%URI{
+          scheme: scheme(conn),
+          host: host(conn),
+          path: Enum.join([namespace(), path_for(data)], "/")
+        })
+      end
 
       def url_for(data, %Plug.Conn{} = conn) do
         URI.to_string(%URI{
           scheme: scheme(conn),
           host: host(conn),
-          path: Enum.join([namespace(), path_for(data)], "/")
+          path: Enum.join([namespace(), path_for(data), id(data)], "/")
         })
       end
 


### PR DESCRIPTION
Hi,

If you want to have a url for you resources which is not equal to your type (e.g. type blog path /blogs), you are currently forced to override url_for and the whole logic for connection / no connection cases and single vs many resources.

To simplify this this PR:

- Delegates resource path resolution to `path_for`, a new overridable callback for `JSONAPI.View`
- Makes `url_for` call `path_for` to determine resource path
- Add a `path` argument to `JSONAPI.View` using macro, to allow compile time declaration like `type` and `namespace`
- Default to returning `type` as the default path in case `path` is missing

It also uses Elixir standard library module `URI` to handle URI generation.

Example usage:

```elixir
defmodule MyView do
  use JSONAPI.View, type: "blog" # path "/blog"
  use JSONAPI.View, type: "blog", namespace: "api" # path "/api/blog", "/api/blog/1", ...
  use JSONAPI.View, type: "blog", path: "blogs" # Defaults to "/blogs", "/blogs/1", ...
  use JSONAPI.View, type: "blog", namespace: "api", path: "blogs" # Defaults to "/api/blogs", "/api/blogs/1", ...

  # or by overriding path_for
  def path_for(_data), do: "blogs"
end
```

Since we are basically not changing the interface, this is fully backwards compatible if anyone is currently overriding `url_for`.