### PR TITLE
Handle empty sparse fields

### DIFF
--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -136,7 +136,7 @@ defmodule JSONAPI.QueryParser do
       requested_fields =
         try do
           value
-          |> String.split(",", trim: true)
+          |> String.split(",")
           |> Enum.map(&underscore/1)
           |> Enum.into(MapSet.new(), &String.to_existing_atom/1)
         rescue

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -144,9 +144,10 @@ defmodule JSONAPI.QueryParser do
           ArgumentError -> raise_invalid_field_names(value, config.view.type())
         end
 
-      unless MapSet.subset?(requested_fields, valid_fields) do
+      size = MapSet.size(requested_fields)
+      case MapSet.subset?(requested_fields, valid_fields) do
         # no fields if empty - https://jsonapi.org/format/#fetching-sparse-fieldsets
-        if MapSet.size(requested_fields) != 0 do
+        false when size > 0 ->
           bad_fields =
             requested_fields
             |> MapSet.difference(valid_fields)
@@ -154,10 +155,9 @@ defmodule JSONAPI.QueryParser do
             |> Enum.join(",")
 
           raise_invalid_field_names(bad_fields, config.view.type())
-        end
+        _ -> 
+          %{acc | fields: Map.put(acc.fields, type, MapSet.to_list(requested_fields))}
       end
-
-      %{acc | fields: Map.put(acc.fields, type, MapSet.to_list(requested_fields))}
     end)
   end
 

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -136,14 +136,14 @@ defmodule JSONAPI.QueryParser do
       requested_fields =
         try do
           value
-          |> String.split(",")
+          |> String.split(",", trim: true)
           |> Enum.map(&underscore/1)
           |> Enum.into(MapSet.new(), &String.to_existing_atom/1)
         rescue
           ArgumentError -> raise_invalid_field_names(value, config.view.type())
         end
 
-      unless MapSet.subset?(requested_fields, valid_fields) do
+      unless MapSet.size(requested_fields) == 0 and MapSet.subset?(requested_fields, valid_fields) do
         bad_fields =
           requested_fields
           |> MapSet.difference(valid_fields)

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -137,7 +137,7 @@ defmodule JSONAPI.QueryParser do
         try do
           value
           |> String.split(",")
-          |> Enum.filter(& &1 !== "")
+          |> Enum.filter(&(&1 !== ""))
           |> Enum.map(&underscore/1)
           |> Enum.into(MapSet.new(), &String.to_existing_atom/1)
         rescue

--- a/lib/jsonapi/plugs/query_parser.ex
+++ b/lib/jsonapi/plugs/query_parser.ex
@@ -145,6 +145,7 @@ defmodule JSONAPI.QueryParser do
         end
 
       size = MapSet.size(requested_fields)
+
       case MapSet.subset?(requested_fields, valid_fields) do
         # no fields if empty - https://jsonapi.org/format/#fetching-sparse-fieldsets
         false when size > 0 ->
@@ -155,7 +156,8 @@ defmodule JSONAPI.QueryParser do
             |> Enum.join(",")
 
           raise_invalid_field_names(bad_fields, config.view.type())
-        _ -> 
+
+        _ ->
           %{acc | fields: Map.put(acc.fields, type, MapSet.to_list(requested_fields))}
       end
     end)

--- a/test/jsonapi/plugs/query_parser_test.exs
+++ b/test/jsonapi/plugs/query_parser_test.exs
@@ -110,6 +110,11 @@ defmodule JSONAPI.QueryParserTest do
     assert parse_fields(config, %{"mytype" => "id,text"}).fields == %{"mytype" => [:id, :text]}
   end
 
+  test "parse_fields/2 turns an empty fields map into an empty list" do
+    config = struct(Config, view: MyView)
+    assert parse_fields(config, %{"mytype" => ""}).fields == %{"mytype" => []}
+  end
+
   test "parse_fields/2 raises on invalid parsing" do
     config = struct(Config, view: MyView)
 

--- a/test/jsonapi_test.exs
+++ b/test/jsonapi_test.exs
@@ -344,6 +344,23 @@ defmodule JSONAPITest do
                "first-character" => "H"
              } == attributes
     end
+
+    test "handles empty sparse fields properly" do
+      conn =
+        :get
+        |> conn("/posts?include=other_user.company&fields[mytype]=")
+        |> Plug.Conn.assign(:data, [@default_data])
+        |> Plug.Conn.fetch_query_params()
+        |> MyPostPlug.call([])
+
+      assert %{
+               "data" => [
+                 %{"attributes" => attributes}
+               ]
+             } = Jason.decode!(conn.resp_body)
+
+      assert %{} == attributes
+    end
   end
 
   test "omits explicit nil meta values as per http://jsonapi.org/format/#document-meta" do


### PR DESCRIPTION
https://jsonapi.org/format/#fetching-sparse-fieldsets

> An empty value indicates that no fields should be returned.


The JSONAPI has taken a strict stance on what an empty query param should mean.  They stated it should return no fields instead of leaving it up to the implementer.